### PR TITLE
fix: send dedicated RESET_MESSAGE so non-host users return to voting screen

### DIFF
--- a/planningpoker-api/src/main/java/com/richashworth/planningpoker/controller/GameController.java
+++ b/planningpoker-api/src/main/java/com/richashworth/planningpoker/controller/GameController.java
@@ -146,6 +146,7 @@ public class GameController {
       logger.info("{} has reset session {}", userName, sessionId);
       sessionManager.resetSession(sessionId);
     }
+    messagingUtils.sendResetNotification(sessionId);
     messagingUtils.burstResultsMessages(sessionId);
   }
 

--- a/planningpoker-api/src/main/java/com/richashworth/planningpoker/util/MessagingUtils.java
+++ b/planningpoker-api/src/main/java/com/richashworth/planningpoker/util/MessagingUtils.java
@@ -62,6 +62,11 @@ public class MessagingUtils {
     }
   }
 
+  public void sendResetNotification(String sessionId) {
+    template.convertAndSend(
+        getTopic(TOPIC_RESULTS, sessionId), new Message(MessageType.RESET_MESSAGE, Map.of()));
+  }
+
   Message resultsMessage(Object payload) {
     return new Message(MessageType.RESULTS_MESSAGE, payload);
   }
@@ -72,7 +77,8 @@ public class MessagingUtils {
 
   private enum MessageType {
     USERS_MESSAGE,
-    RESULTS_MESSAGE
+    RESULTS_MESSAGE,
+    RESET_MESSAGE
   }
 
   private record Message(MessageType type, Object payload) {}

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/GameControllerTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/GameControllerTest.java
@@ -123,8 +123,8 @@ class GameControllerTest extends AbstractControllerTest {
     when(sessionManager.getSessionUsers(SESSION_ID)).thenReturn(Lists.newArrayList(USER_NAME));
     gameController.reset(SESSION_ID, USER_NAME);
     verify(sessionManager).resetSession(SESSION_ID);
+    verify(messagingUtils).sendResetNotification(SESSION_ID);
     verify(messagingUtils).burstResultsMessages(SESSION_ID);
-    verifyNoMoreInteractions(sessionManager);
   }
 
   @Test
@@ -260,6 +260,7 @@ class GameControllerTest extends AbstractControllerTest {
     when(sessionManager.getSessionUsers(SESSION_ID)).thenReturn(Lists.newArrayList(USER_NAME));
     gameController.reset(SESSION_ID, USER_NAME);
     verify(sessionManager).resetSession(SESSION_ID);
+    verify(messagingUtils).sendResetNotification(SESSION_ID);
     verify(messagingUtils).burstResultsMessages(SESSION_ID);
   }
 }

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/util/MessagingUtilsTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/util/MessagingUtilsTest.java
@@ -114,6 +114,12 @@ class MessagingUtilsTest {
   }
 
   @Test
+  void testSendResetNotification() {
+    messagingUtils.sendResetNotification(SESSION_ID);
+    verify(template).convertAndSend(eq(getTopic(TOPIC_RESULTS, SESSION_ID)), any());
+  }
+
+  @Test
   void testBurstUsersMessages() {
     when(sessionManager.getSessionUsers(SESSION_ID)).thenReturn(USERS);
     when(sessionManager.getHost(SESSION_ID)).thenReturn(USER_NAME);

--- a/planningpoker-web/src/pages/PlayGame.jsx
+++ b/planningpoker-web/src/pages/PlayGame.jsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom'
 import Box from '@mui/material/Box'
 import GamePane from '../containers/GamePane'
 import useStomp from '../hooks/useStomp'
-import { resultsUpdated, usersUpdated, kicked, labelUpdated } from '../actions'
+import { resultsUpdated, usersUpdated, kicked, labelUpdated, RESET_SESSION } from '../actions'
 import { API_ROOT_URL } from '../config/Constants'
 import axios from 'axios'
 
@@ -61,6 +61,8 @@ export default function PlayGame() {
           if (label !== undefined) dispatch(labelUpdated(label))
           return
         }
+        case 'RESET_MESSAGE':
+          return dispatch({ type: RESET_SESSION })
         case 'USERS_MESSAGE':
           return dispatch(usersUpdated(msg.payload))
         default:

--- a/planningpoker-web/src/reducers/__tests__/reducer_vote.test.js
+++ b/planningpoker-web/src/reducers/__tests__/reducer_vote.test.js
@@ -86,6 +86,27 @@ describe('vote reducer', () => {
     })
   })
 
+  describe('non-host reset via WebSocket RESET_MESSAGE', () => {
+    it('returns to voting screen when RESET_SESSION arrives via WebSocket', () => {
+      let state = false
+
+      // Non-host votes
+      state = reducer(state, {
+        type: VOTE_OPTIMISTIC,
+        payload: { userName: 'alice', estimateValue: '5' },
+      })
+      expect(state).toBe(true)
+
+      // Results confirm
+      state = reducer(state, resultsAction([{ userName: 'alice', estimateValue: '5' }]))
+      expect(state).toBe(true)
+
+      // Host clicks "Next Item" — backend sends RESET_MESSAGE, frontend dispatches RESET_SESSION
+      state = reducer(state, { type: RESET_SESSION })
+      expect(state).toBe(false) // non-host should see voting screen
+    })
+  })
+
   describe('stale empty burst from prior reset', () => {
     it('does not flash back to vote screen after new round vote', () => {
       let state = false

--- a/planningpoker-web/tests/planning-poker.spec.js
+++ b/planningpoker-web/tests/planning-poker.spec.js
@@ -203,6 +203,34 @@ test.describe('Multi-User Flows', () => {
     await playerCtx.close();
   });
 
+  test('host clicking Next Item returns non-host to voting screen', async ({ browser }) => {
+    const hostCtx = await browser.newContext();
+    const hostPage = await hostCtx.newPage();
+    const sessionId = await hostGame(hostPage, 'Alice');
+
+    const playerCtx = await browser.newContext();
+    const playerPage = await playerCtx.newPage();
+    await joinGame(playerPage, 'Bob', sessionId);
+
+    // Both vote
+    await hostPage.getByText('5', { exact: true }).click();
+    await playerPage.getByText('8', { exact: true }).click();
+
+    // Both see results
+    await expect(hostPage.getByText('Results')).toBeVisible({ timeout: 15000 });
+    await expect(playerPage.getByText('Results')).toBeVisible({ timeout: 15000 });
+
+    // Host clicks Next Item
+    await hostPage.getByRole('button', { name: 'Next Item' }).click();
+
+    // Both should return to voting screen
+    await expect(hostPage.getByText('Cast your estimate')).toBeVisible({ timeout: 10000 });
+    await expect(playerPage.getByText('Cast your estimate')).toBeVisible({ timeout: 10000 });
+
+    await hostCtx.close();
+    await playerCtx.close();
+  });
+
   test('three users vote and all see results', async ({ browser }) => {
     const hostCtx = await browser.newContext();
     const hostPage = await hostCtx.newPage();


### PR DESCRIPTION
Commit 476c1ee changed the vote reducer to preserve `voted = true` when
empty RESULTS_UPDATED arrives, protecting against stale burst flicker.
However, this broke reset for non-host users: they never dispatch
RESET_SESSION locally (only the host does via HTTP), so they relied on
empty results to flip `voted` back to false — which now no longer happens.

Fix: the backend now sends a dedicated RESET_MESSAGE via WebSocket before
the results burst. All clients (including non-host) handle this by
dispatching RESET_SESSION, which correctly sets `voted = false`. The
stale-burst protection in the RESULTS_UPDATED handler remains intact.

https://claude.ai/code/session_016NEvx2WD4wJDB9H7bp9tBv