### PR TITLE
refactor(csv-export): drop derived stats columns, include all session players

### DIFF
--- a/planningpoker-web/src/containers/Results.jsx
+++ b/planningpoker-web/src/containers/Results.jsx
@@ -8,7 +8,7 @@ import DownloadIcon from '@mui/icons-material/Download'
 import ResultsTable from './ResultsTable'
 import ResultsChart from './ResultsChart'
 import { resetSession, roundCompleted } from '../actions'
-import { calcConsensus, calcStats } from '../utils/consensus'
+import { calcConsensus } from '../utils/consensus'
 import { generateCsv, downloadCsv } from '../utils/csvExport'
 
 export default function Results({ consensusOverride, setConsensusOverride }) {
@@ -19,6 +19,7 @@ export default function Results({ consensusOverride, setConsensusOverride }) {
   const currentLabel = useSelector((state) => state.game.currentLabel)
   const results = useSelector((state) => state.results)
   const rounds = useSelector((state) => state.rounds)
+  const users = useSelector((state) => state.users)
   const legalEstimates = useSelector((state) => state.game.legalEstimates)
 
   const autoConsensus = calcConsensus(results)
@@ -26,16 +27,11 @@ export default function Results({ consensusOverride, setConsensusOverride }) {
   const totalRounds = rounds.length + (results.length > 0 ? 1 : 0)
 
   const handleNextItem = () => {
-    const stats = calcStats(results)
     const round = {
       label: currentLabel,
       consensus: consensusOverride || calcConsensus(results),
       votes: [...results],
       timestamp: new Date().toISOString(),
-      mode: stats.mode,
-      min: stats.min,
-      max: stats.max,
-      variance: stats.variance,
     }
     dispatch(roundCompleted(round))
     setConsensusOverride(null)
@@ -43,19 +39,16 @@ export default function Results({ consensusOverride, setConsensusOverride }) {
   }
 
   const handleExportCsv = () => {
-    const stats = calcStats(results)
     const currentRound = {
       label: currentLabel,
       consensus: consensusOverride || calcConsensus(results),
       votes: [...results],
       timestamp: new Date().toISOString(),
-      mode: stats.mode,
-      min: stats.min,
-      max: stats.max,
-      variance: stats.variance,
     }
     const allRounds = [...rounds, currentRound]
-    const allPlayers = [...new Set(allRounds.flatMap((r) => r.votes.map((v) => v.userName)))].sort()
+    // Include all current session users plus any historical voters (who may have since left)
+    const historicalVoters = allRounds.flatMap((r) => r.votes.map((v) => v.userName))
+    const allPlayers = [...new Set([...users, ...historicalVoters])].sort()
     const csv = generateCsv(allRounds, allPlayers)
     downloadCsv(csv, `planning-poker-${sessionId}.csv`)
   }

--- a/planningpoker-web/src/utils/csvExport.js
+++ b/planningpoker-web/src/utils/csvExport.js
@@ -27,21 +27,12 @@ function escapeField(value) {
 /**
  * Generate a CSV string from round history.
  *
- * @param {Array<{label: string, consensus: string, timestamp: string, mode: string, min: string|null, max: string|null, variance: string|null, votes: Array<{userName: string, estimateValue: string}>}>} rounds
+ * @param {Array<{label: string, consensus: string, timestamp: string, votes: Array<{userName: string, estimateValue: string}>}>} rounds
  * @param {string[]} playerNames - Sorted array of all unique player names across rounds
  * @returns {string} CSV string
  */
 export function generateCsv(rounds, playerNames) {
-  const headers = [
-    'Label',
-    'Consensus',
-    'Timestamp',
-    'Mode',
-    'Min',
-    'Max',
-    'Variance',
-    ...playerNames,
-  ]
+  const headers = ['Label', 'Consensus', 'Timestamp', ...playerNames]
   const rows = [headers.join(',')]
 
   for (const round of rounds) {
@@ -56,10 +47,6 @@ export function generateCsv(rounds, playerNames) {
       escapeField(round.label || ''),
       escapeField(round.consensus || ''),
       escapeField(round.timestamp || ''),
-      escapeField(round.mode || ''),
-      escapeField(round.min || ''),
-      escapeField(round.max || ''),
-      escapeField(round.variance || ''),
       ...playerVotes,
     ]
 

--- a/planningpoker-web/src/utils/csvExport.test.js
+++ b/planningpoker-web/src/utils/csvExport.test.js
@@ -8,10 +8,6 @@ describe('generateCsv', () => {
       label: 'Login page',
       consensus: '5',
       timestamp: '2026-04-08T10:00:00.000Z',
-      mode: '5',
-      min: '3',
-      max: '8',
-      variance: '2.00',
       votes: [
         { userName: 'Alice', estimateValue: '5' },
         { userName: 'Bob', estimateValue: '3' },
@@ -21,10 +17,6 @@ describe('generateCsv', () => {
       label: 'Dashboard',
       consensus: '8',
       timestamp: '2026-04-08T10:05:00.000Z',
-      mode: '8',
-      min: '5',
-      max: '13',
-      variance: '10.67',
       votes: [
         { userName: 'Alice', estimateValue: '8' },
         { userName: 'Bob', estimateValue: '8' },
@@ -36,33 +28,15 @@ describe('generateCsv', () => {
     const playerNames = ['Alice', 'Bob']
     const csv = generateCsv(rounds, playerNames)
     const lines = csv.split('\n')
-    expect(lines[0]).toBe('Label,Consensus,Timestamp,Mode,Min,Max,Variance,Alice,Bob')
+    expect(lines[0]).toBe('Label,Consensus,Timestamp,Alice,Bob')
   })
 
   it('produces correct data rows', () => {
     const playerNames = ['Alice', 'Bob']
     const csv = generateCsv(rounds, playerNames)
     const lines = csv.split('\n')
-    expect(lines[1]).toBe('Login page,5,2026-04-08T10:00:00.000Z,5,3,8,2.00,5,3')
-    expect(lines[2]).toBe('Dashboard,8,2026-04-08T10:05:00.000Z,8,5,13,10.67,8,8')
-  })
-
-  it('uses empty string for missing numeric stats', () => {
-    const nonNumericRound = [
-      {
-        label: 'T-shirt item',
-        consensus: 'M',
-        timestamp: '2026-04-08T10:00:00.000Z',
-        mode: 'M',
-        min: null,
-        max: null,
-        variance: null,
-        votes: [{ userName: 'Alice', estimateValue: 'M' }],
-      },
-    ]
-    const csv = generateCsv(nonNumericRound, ['Alice'])
-    const lines = csv.split('\n')
-    expect(lines[1]).toBe('T-shirt item,M,2026-04-08T10:00:00.000Z,M,,,,' + 'M')
+    expect(lines[1]).toBe('Login page,5,2026-04-08T10:00:00.000Z,5,3')
+    expect(lines[2]).toBe('Dashboard,8,2026-04-08T10:05:00.000Z,8,8')
   })
 
   it('uses empty string for missing player vote', () => {
@@ -71,16 +45,12 @@ describe('generateCsv', () => {
         label: 'Item 1',
         consensus: '5',
         timestamp: '2026-04-08T10:00:00.000Z',
-        mode: '5',
-        min: '5',
-        max: '5',
-        variance: '0.00',
         votes: [{ userName: 'Alice', estimateValue: '5' }],
       },
     ]
     const csv = generateCsv(roundWithMissingPlayer, ['Alice', 'Bob'])
     const lines = csv.split('\n')
-    expect(lines[1]).toBe('Item 1,5,2026-04-08T10:00:00.000Z,5,5,5,0.00,5,')
+    expect(lines[1]).toBe('Item 1,5,2026-04-08T10:00:00.000Z,5,')
   })
 
   it('escapes values with commas in double quotes', () => {
@@ -89,10 +59,6 @@ describe('generateCsv', () => {
         label: 'Fix login, signup flow',
         consensus: '5',
         timestamp: '2026-04-08T10:00:00.000Z',
-        mode: '5',
-        min: '5',
-        max: '5',
-        variance: '0.00',
         votes: [{ userName: 'Alice', estimateValue: '5' }],
       },
     ]
@@ -107,10 +73,6 @@ describe('generateCsv', () => {
         label: 'He said "hello"',
         consensus: '5',
         timestamp: '2026-04-08T10:00:00.000Z',
-        mode: '5',
-        min: '5',
-        max: '5',
-        variance: '0.00',
         votes: [{ userName: 'Alice', estimateValue: '5' }],
       },
     ]
@@ -126,10 +88,6 @@ describe('generateCsv', () => {
         label: formulaLabel,
         consensus: '5',
         timestamp: '2026-04-08T10:00:00.000Z',
-        mode: '5',
-        min: '5',
-        max: '5',
-        variance: '0.00',
         votes: [{ userName: 'Alice', estimateValue: '5' }],
       },
     ]

--- a/planningpoker-web/tests/session-labels-csv.spec.js
+++ b/planningpoker-web/tests/session-labels-csv.spec.js
@@ -391,6 +391,63 @@ test.describe('CSV Export', () => {
       await playerCtx.close()
     }
   })
+
+  test('CSV has no stats columns and includes non-voting players', async ({ browser }) => {
+    const hostCtx = await browser.newContext()
+    const voterCtx = await browser.newContext()
+    const lurkerCtx = await browser.newContext()
+    try {
+      const hostPage = await hostCtx.newPage()
+      const sessionId = await hostGame(hostPage, 'Alice')
+
+      const voterPage = await voterCtx.newPage()
+      await joinGame(voterPage, 'Bob', sessionId)
+
+      const lurkerPage = await lurkerCtx.newPage()
+      await joinGame(lurkerPage, 'Carol', sessionId)
+
+      await waitForWsReady(hostPage, sessionId, 'Carol')
+
+      // Only Alice and Bob vote; Carol does not
+      await hostPage.getByText('5', { exact: true }).click()
+      await voterPage.getByText('5', { exact: true }).click()
+      await expect(hostPage.getByText('Results')).toBeVisible({ timeout: 15000 })
+
+      const exportBtn = hostPage.getByRole('button', { name: 'Export CSV' })
+      await exportBtn.scrollIntoViewIfNeeded()
+      const [download] = await Promise.all([hostPage.waitForEvent('download'), exportBtn.click()])
+
+      const content = await download.path().then((p) => {
+        // eslint-disable-next-line no-undef
+        const fs = require('fs')
+        return fs.readFileSync(p, 'utf-8')
+      })
+
+      const [header, dataRow] = content.split('\n')
+
+      // Stats columns removed
+      expect(header).not.toMatch(/\bMode\b/)
+      expect(header).not.toMatch(/\bMin\b/)
+      expect(header).not.toMatch(/\bMax\b/)
+      expect(header).not.toMatch(/\bVariance\b/)
+
+      // Header is exactly: Label,Consensus,Timestamp, then sorted players
+      expect(header).toBe('Label,Consensus,Timestamp,Alice,Bob,Carol')
+
+      // Data row: empty label, consensus 5, iso timestamp, Alice=5, Bob=5, Carol=(empty)
+      // Columns 0..2 = Label/Consensus/Timestamp; 3/4/5 = Alice/Bob/Carol
+      const cols = dataRow.split(',')
+      expect(cols[0]).toBe('') // no label set
+      expect(cols[1]).toBe('5')
+      expect(cols[3]).toBe('5') // Alice
+      expect(cols[4]).toBe('5') // Bob
+      expect(cols[5]).toBe('') // Carol — non-voter, blank
+    } finally {
+      await hostCtx.close()
+      await voterCtx.close()
+      await lurkerCtx.close()
+    }
+  })
 })
 
 test.describe('Accessibility announcements', () => {


### PR DESCRIPTION
## Summary
- Drop derived stats columns (mean/median/mode) from CSV export — those live in the UI, not the export
- Include all session players in the CSV, even non-voters (empty vote cell)
- Adds e2e coverage verifying the new format

## Test plan
- [ ] `npm test` (vitest) passes for `csvExport.test.js`
- [ ] `npx playwright test session-labels-csv.spec.js` passes
- [ ] Manual: export a session with voters + non-voters, confirm CSV contains all players and no stats columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)