### PR TITLE
fix(ws): show host in joiner's player list on first round

### DIFF
--- a/planningpoker-web/src/pages/PlayGame.jsx
+++ b/planningpoker-web/src/pages/PlayGame.jsx
@@ -109,6 +109,10 @@ export default function PlayGame() {
             )
             dispatch(kicked())
           })
+      } else {
+        // Initial connect: the USERS_MESSAGE broadcast fired by createSession/joinSession
+        // went out before we subscribed, so pull current state now.
+        dispatch(refresh(sessionId, playerName))
       }
       wasConnected.current = true
     }

--- a/planningpoker-web/tests/planning-poker.spec.js
+++ b/planningpoker-web/tests/planning-poker.spec.js
@@ -178,6 +178,29 @@ test.describe('Multi-User Flows', () => {
     await playerCtx.close();
   });
 
+  test('host is visible in joiner players list in round 1 before any voting', async ({
+    browser,
+  }) => {
+    const hostCtx = await browser.newContext();
+    const hostPage = await hostCtx.newPage();
+    const sessionId = await hostGame(hostPage, 'Alice');
+
+    const playerCtx = await browser.newContext();
+    const playerPage = await playerCtx.newPage();
+    await joinGame(playerPage, 'Bob', sessionId);
+
+    // Round 1, no votes cast: joiner must see the host in the Players list
+    const joinerPlayers = playerPage.getByRole('main').getByText('Alice', { exact: true });
+    await expect(joinerPlayers).toBeVisible({ timeout: 10000 });
+
+    // And the host must also see the joiner in the Players list
+    const hostPlayers = hostPage.getByRole('main').getByText('Bob', { exact: true });
+    await expect(hostPlayers).toBeVisible({ timeout: 10000 });
+
+    await hostCtx.close();
+    await playerCtx.close();
+  });
+
   test('non-host does not see Next Item button', async ({ browser }) => {
     const hostCtx = await browser.newContext();
     const hostPage = await hostCtx.newPage();


### PR DESCRIPTION
## Summary
- `createSession`/`joinSession` broadcast `USERS_MESSAGE` to `/topic/users/{sessionId}` before the client has mounted `PlayGame` and subscribed, so joiners never received the initial roster until another user event fired (next joiner, vote reveal, reset, etc.).
- `PlayGame.jsx` already had refresh-on-connect logic but gated it behind `wasConnected.current`, running only on *reconnect*. Now dispatches `refresh()` on the initial connect too, pulling current users/results via `GET /refresh`.

## Test plan
- [x] New Playwright regression (`host is visible in joiner players list in round 1 before any voting`) fails without the fix and passes with it.
- [x] Full Playwright suite: 41/41 passing locally.
- [x] Backend `./gradlew planningpoker-api:build`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)