### PR TITLE
fix(logout): suppress 'removed by host' toast on self-logout

### DIFF
--- a/planningpoker-web/src/actions/index.js
+++ b/planningpoker-web/src/actions/index.js
@@ -84,17 +84,18 @@ export function createGame(playerName, schemeOptions, onSuccess) {
 
 export function leaveGame(playerName, sessionId, onSuccess) {
   return async (dispatch) => {
+    // Reset local state first so the users-list broadcast that follows the
+    // server-side logout can't trip PlayGame's kick-detection effect on us.
+    dispatch({ type: LEAVE_GAME })
     try {
       await axios.post(
         `${API_ROOT_URL}/logout`,
         new URLSearchParams({ userName: playerName, sessionId }),
       )
-      dispatch({ type: LEAVE_GAME })
-      if (onSuccess) onSuccess()
     } catch (err) {
       console.error('Failed to leave session', err)
-      dispatch({ type: LEAVE_GAME })
     }
+    if (onSuccess) onSuccess()
   }
 }
 

--- a/planningpoker-web/tests/planning-poker.spec.js
+++ b/planningpoker-web/tests/planning-poker.spec.js
@@ -178,6 +178,45 @@ test.describe('Multi-User Flows', () => {
     await playerCtx.close();
   });
 
+  test('self-initiated logout does not show kicked toast', async ({ browser }) => {
+    const hostCtx = await browser.newContext();
+    const hostPage = await hostCtx.newPage();
+    const sessionId = await hostGame(hostPage, 'Alice');
+
+    const playerCtx = await browser.newContext();
+    const playerPage = await playerCtx.newPage();
+    await joinGame(playerPage, 'Bob', sessionId);
+
+    // Wait until both clients have finished subscribing
+    await expect(hostPage.getByRole('main').getByText('Bob', { exact: true })).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Deterministically reproduce the race: hold the /logout response client-side
+    // for 800ms so the server-side USERS_MESSAGE broadcast always arrives first.
+    await playerPage.route('**/logout', async (route) => {
+      await new Promise((r) => setTimeout(r, 800));
+      await route.continue();
+    });
+
+    // Bob logs himself out
+    await playerPage.getByRole('button', { name: /Bob/i }).click();
+    await playerPage.getByRole('menuitem', { name: 'Log out' }).click();
+    await expect(playerPage).toHaveURL('/');
+
+    // No "removed by the host" toast should appear, immediately or after a beat
+    await expect(
+      playerPage.getByText(/removed from the session by the host/i),
+    ).not.toBeVisible();
+    await playerPage.waitForTimeout(500);
+    await expect(
+      playerPage.getByText(/removed from the session by the host/i),
+    ).not.toBeVisible();
+
+    await hostCtx.close();
+    await playerCtx.close();
+  });
+
   test('host is visible in joiner players list in round 1 before any voting', async ({
     browser,
   }) => {


### PR DESCRIPTION
## Summary
- On self-logout, the `/logout` broadcast a `USERS_MESSAGE` before the HTTP response returned. If the WS message won the race, `PlayGame`'s kick-detection effect fired `kicked()`, storing the "removed by the host" message and showing it as a toast on `/`.
- Fix: dispatch `LEAVE_GAME` synchronously in the `leaveGame` thunk before the HTTP POST. `isUserRegistered` flips false immediately, so the kick-detection effect bails before it can fire.

## Test plan
- [x] New Playwright regression deterministically reproduces the race by delaying `/logout` client-side: 3/3 fail on master, 3/3 pass with this change.
- [x] Full Playwright suite: 41/41 passing locally.
- [x] Frontend unit tests: 91/91 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)