### PR TITLE
fix(ui): rename "Round label" placeholder to "Item label"

### DIFF
--- a/planningpoker-web/src/containers/Vote.jsx
+++ b/planningpoker-web/src/containers/Vote.jsx
@@ -142,7 +142,7 @@ export default function Vote() {
               {isAdmin ? (
                 <TextField
                   variant="standard"
-                  placeholder="Round label (optional)"
+                  placeholder="Item label (optional)"
                   fullWidth
                   size="small"
                   value={labelInput}

--- a/planningpoker-web/tests/session-labels-csv.spec.js
+++ b/planningpoker-web/tests/session-labels-csv.spec.js
@@ -58,16 +58,16 @@ test.describe('Session Labels', () => {
       await joinGame(playerPage, 'Bob', sessionId)
 
       // Host sees the inline label input
-      await expect(hostPage.getByPlaceholder('Round label (optional)')).toBeVisible()
+      await expect(hostPage.getByPlaceholder('Item label (optional)')).toBeVisible()
 
       // Non-host should NOT have a label input
-      await expect(playerPage.getByPlaceholder('Round label (optional)')).not.toBeVisible()
+      await expect(playerPage.getByPlaceholder('Item label (optional)')).not.toBeVisible()
 
       // Wait for player WebSocket to deliver USERS_MESSAGE (host name appears in users list)
       await waitForWsReady(playerPage, sessionId, 'Alice')
 
       // Host types a label and presses Enter to commit
-      const labelInput = hostPage.getByPlaceholder('Round label (optional)')
+      const labelInput = hostPage.getByPlaceholder('Item label (optional)')
       await labelInput.fill('Login page redesign')
       await labelInput.press('Enter')
 
@@ -95,7 +95,7 @@ test.describe('Session Labels', () => {
       await waitForWsReady(playerPage, sessionId, 'Alice')
 
       // Host opens the banner, sets a label and commits with Enter
-      const sprintInput = hostPage.getByPlaceholder('Round label (optional)')
+      const sprintInput = hostPage.getByPlaceholder('Item label (optional)')
       await sprintInput.fill('Sprint 42')
       await sprintInput.press('Enter')
 
@@ -133,7 +133,7 @@ test.describe('Session Labels', () => {
       await waitForWsReady(playerPage, sessionId, 'Alice')
 
       // Host opens banner, sets label and commits with Enter
-      const itemAInput = hostPage.getByPlaceholder('Round label (optional)')
+      const itemAInput = hostPage.getByPlaceholder('Item label (optional)')
       await itemAInput.fill('Item A')
       await itemAInput.press('Enter')
       await expect(playerPage.getByText('Item A')).toBeVisible({ timeout: 15000 })
@@ -150,7 +150,7 @@ test.describe('Session Labels', () => {
       await expect(hostPage.getByText('Cast your estimate')).toBeVisible({
         timeout: 15000,
       })
-      await expect(hostPage.getByPlaceholder('Round label (optional)')).toHaveValue('')
+      await expect(hostPage.getByPlaceholder('Item label (optional)')).toHaveValue('')
     } finally {
       await hostCtx.close()
       await playerCtx.close()
@@ -170,7 +170,7 @@ test.describe('Session Labels', () => {
       // Wait for player WebSocket to deliver USERS_MESSAGE (host name appears in users list)
       await waitForWsReady(playerPage, sessionId, 'Alice')
 
-      const labelInput = hostPage.getByPlaceholder('Round label (optional)')
+      const labelInput = hostPage.getByPlaceholder('Item label (optional)')
 
       // Host types — do not yet commit. Non-host should NOT see it within debounce window.
       await labelInput.fill('Deliberate')
@@ -199,7 +199,7 @@ test.describe('Session Labels', () => {
       // Wait for player WebSocket to deliver USERS_MESSAGE (host name appears in users list)
       await waitForWsReady(playerPage, sessionId, 'Alice')
 
-      const labelInput = hostPage.getByPlaceholder('Round label (optional)')
+      const labelInput = hostPage.getByPlaceholder('Item label (optional)')
 
       // Host types and presses Enter to submit
       await labelInput.fill('Via Enter')
@@ -228,7 +228,7 @@ test.describe('Session Labels', () => {
       // Wait for player WebSocket to deliver USERS_MESSAGE (host name appears in users list)
       await waitForWsReady(playerPage, sessionId, 'Alice')
 
-      const labelInput = hostPage.getByPlaceholder('Round label (optional)')
+      const labelInput = hostPage.getByPlaceholder('Item label (optional)')
 
       // Host sets a label
       await labelInput.fill('Something')
@@ -238,7 +238,7 @@ test.describe('Session Labels', () => {
       })
 
       // Re-enter edit mode, clear input, press Enter — non-host should no longer see label
-      const labelInput2 = hostPage.getByPlaceholder('Round label (optional)')
+      const labelInput2 = hostPage.getByPlaceholder('Item label (optional)')
       await labelInput2.fill('')
       await labelInput2.press('Enter')
       await expect(playerPage.getByText('Something')).not.toBeVisible({
@@ -349,7 +349,7 @@ test.describe('CSV Export', () => {
       await waitForWsReady(playerPage, sessionId, 'Alice')
 
       // Set label via banner → Enter commit
-      const story1Input = hostPage.getByPlaceholder('Round label (optional)')
+      const story1Input = hostPage.getByPlaceholder('Item label (optional)')
       await story1Input.fill('Story 1')
       await story1Input.press('Enter')
       await expect(playerPage.getByText('Story 1')).toBeVisible({
@@ -511,7 +511,7 @@ test.describe('Accessibility announcements', () => {
       })
 
       // Enter edit mode via banner
-      const labelInput = hostPage.getByPlaceholder('Round label (optional)')
+      const labelInput = hostPage.getByPlaceholder('Item label (optional)')
       await expect(labelInput).toBeVisible()
 
       // Type 'Hello' character-by-character well under the 1000ms debounce window

--- a/scripts/record-demo.mjs
+++ b/scripts/record-demo.mjs
@@ -32,7 +32,7 @@ const PLAYERS = ['Bob', 'Carol', 'Dave', 'Eve', 'Frank', 'Grace', 'Henry', 'Iris
 const ROUND_1 = { Alice: '5', Bob: '5', Carol: '5', Dave: '3', Eve: '5', Frank: '5', Grace: '5', Henry: '5', Iris: '8', Jack: '13' };
 const ROUND_2 = { Alice: '8', Bob: '8', Carol: '13', Dave: '8', Eve: '8', Frank: '8', Grace: '8', Henry: '5', Iris: '8', Jack: '8' };
 
-// Round labels (descriptions) the host types before each vote.
+// Item labels (descriptions) the host types before each vote.
 const ROUND_1_LABEL = 'AUTH-142 — OAuth login with Google';
 const ROUND_2_LABEL = 'AUTH-143 — Password reset via email';
 
@@ -79,7 +79,7 @@ async function castVote(page, value) {
 // In Option F the banner is click-to-edit: we first click the banner to reveal
 // the TextField, then pressSequentially so viewers see the text appear.
 async function setRoundLabel(hostPage, label) {
-  const field = hostPage.getByPlaceholder('Round label (optional)');
+  const field = hostPage.getByPlaceholder('Item label (optional)');
   await field.waitFor({ timeout: 5000 });
   await field.fill('');
   await field.pressSequentially(label, { delay: 45 });


### PR DESCRIPTION
## Summary
- The round-label field identifies the item being estimated (story, ticket, task), not the estimation round. "Item label" matches the surrounding UI vocabulary (Next Item button) and how teams naturally refer to the thing they're voting on.

## Scope
- `planningpoker-web/src/containers/Vote.jsx` — placeholder text
- `planningpoker-web/tests/session-labels-csv.spec.js` — test locators
- `scripts/record-demo.mjs` — demo-recorder selector + comment

## Test plan
- [x] Label spec file: 16/16 passing locally (`npx playwright test tests/session-labels-csv.spec.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)