### PR TITLE
feat(ui): replace consensus dropdown with card-rail picker

### DIFF
--- a/planningpoker-web/src/components/ConsensusCardRail.jsx
+++ b/planningpoker-web/src/components/ConsensusCardRail.jsx
@@ -1,0 +1,125 @@
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+
+export default function ConsensusCardRail({
+  legalEstimates,
+  results,
+  autoConsensus,
+  value,
+  onChange,
+}) {
+  const counts = {}
+  for (const { estimateValue } of results) {
+    counts[estimateValue] = (counts[estimateValue] || 0) + 1
+  }
+
+  return (
+    <Box sx={{ minWidth: 0, pt: 1 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'baseline',
+          justifyContent: 'space-between',
+          gap: 1,
+          mb: 1,
+          flexWrap: 'wrap',
+        }}
+      >
+        <Typography
+          variant="body2"
+          sx={{ color: 'text.secondary', fontWeight: 500, fontSize: '0.8rem' }}
+        >
+          Lock in the estimate
+        </Typography>
+        {autoConsensus && (
+          <Typography variant="caption" sx={{ color: 'text.disabled', fontSize: '0.75rem' }}>
+            Suggested:{' '}
+            <Box component="strong" sx={{ color: 'text.primary' }}>
+              {autoConsensus}
+            </Box>{' '}
+            (mode)
+          </Typography>
+        )}
+      </Box>
+      <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap', pt: 0.75, pr: 0.75 }}>
+        {legalEstimates.map((v) => {
+          const n = counts[v] || 0
+          const selected = v === value
+          const voted = n > 0
+          return (
+            <Box
+              key={v}
+              component="button"
+              type="button"
+              aria-label={`Set consensus to ${v}${n ? ` (${n} vote${n === 1 ? '' : 's'})` : ''}`}
+              aria-pressed={selected}
+              onClick={() => onChange(v)}
+              sx={{
+                position: 'relative',
+                width: 44,
+                height: 58,
+                p: 0,
+                borderRadius: '6px',
+                border: '1.5px solid',
+                borderColor: selected ? 'primary.main' : 'divider',
+                bgcolor: selected ? 'primary.main' : voted ? 'background.paper' : 'transparent',
+                color: selected ? '#fff' : voted ? 'text.primary' : 'text.disabled',
+                fontFamily: 'inherit',
+                fontSize: '1rem',
+                fontWeight: 700,
+                fontVariantNumeric: 'tabular-nums',
+                cursor: 'pointer',
+                transition: 'all 0.15s ease',
+                transform: selected ? 'translateY(-2px)' : 'translateY(0)',
+                boxShadow: selected
+                  ? '0 4px 12px rgba(102,126,234,0.35)'
+                  : voted
+                    ? '0 1px 2px rgba(0,0,0,0.08)'
+                    : 'none',
+                opacity: !voted && !selected ? 0.45 : 1,
+                '&:hover': {
+                  borderColor: 'primary.main',
+                  opacity: 1,
+                },
+                '&:focus-visible': {
+                  outline: '2px solid',
+                  outlineColor: 'primary.main',
+                  outlineOffset: 2,
+                },
+              }}
+            >
+              {v}
+              {n > 0 && (
+                <Box
+                  component="span"
+                  aria-hidden
+                  sx={{
+                    position: 'absolute',
+                    top: -7,
+                    right: -7,
+                    minWidth: 18,
+                    height: 18,
+                    px: '5px',
+                    borderRadius: '999px',
+                    bgcolor: selected ? 'background.paper' : 'primary.main',
+                    color: selected ? 'primary.main' : '#fff',
+                    fontSize: 11,
+                    fontWeight: 700,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    border: '2px solid',
+                    borderColor: 'background.paper',
+                    lineHeight: 1,
+                  }}
+                >
+                  {n}
+                </Box>
+              )}
+            </Box>
+          )
+        })}
+      </Box>
+    </Box>
+  )
+}

--- a/planningpoker-web/src/containers/Results.jsx
+++ b/planningpoker-web/src/containers/Results.jsx
@@ -2,11 +2,10 @@ import { useSelector, useDispatch } from 'react-redux'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import Button from '@mui/material/Button'
-import Select from '@mui/material/Select'
-import MenuItem from '@mui/material/MenuItem'
 import DownloadIcon from '@mui/icons-material/Download'
 import ResultsTable from './ResultsTable'
 import ResultsChart from './ResultsChart'
+import ConsensusCardRail from '../components/ConsensusCardRail'
 import { resetSession, roundCompleted } from '../actions'
 import { calcConsensus } from '../utils/consensus'
 import { generateCsv, downloadCsv } from '../utils/csvExport'
@@ -66,50 +65,38 @@ export default function Results({ consensusOverride, setConsensusOverride }) {
           flexWrap: 'wrap',
         }}
       >
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-          <Typography variant="h6" sx={{ fontSize: '1.1rem' }}>
-            Results
-          </Typography>
-          {isAdmin && displayConsensus && (
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
-              <Typography variant="body2" color="text.secondary">
-                Consensus:
-              </Typography>
-              <Select
-                size="small"
-                value={displayConsensus}
-                onChange={(e) => {
-                  setConsensusOverride(e.target.value === autoConsensus ? null : e.target.value)
-                }}
-                sx={{ minWidth: 72 }}
-              >
-                {legalEstimates.map((val) => (
-                  <MenuItem key={val} value={val}>
-                    {val}
-                  </MenuItem>
-                ))}
-              </Select>
-            </Box>
-          )}
-        </Box>
+        <Typography variant="h6" sx={{ fontSize: '1.1rem' }}>
+          Results
+        </Typography>
         {isAdmin && (
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-            <Button
-              variant="contained"
-              size="large"
-              disableElevation
-              onClick={handleNextItem}
-              sx={{ px: 4 }}
-            >
-              Next Item
-            </Button>
-          </Box>
+          <Button
+            variant="contained"
+            size="large"
+            disableElevation
+            onClick={handleNextItem}
+            sx={{ px: 4 }}
+          >
+            Next Item
+          </Button>
         )}
       </Box>
       {currentLabel && (
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
           {currentLabel}
         </Typography>
+      )}
+      {isAdmin && displayConsensus && (
+        <Box sx={{ mb: 2.5 }}>
+          <ConsensusCardRail
+            legalEstimates={legalEstimates}
+            results={results}
+            autoConsensus={autoConsensus}
+            value={displayConsensus}
+            onChange={(v) => {
+              setConsensusOverride(v === autoConsensus ? null : v)
+            }}
+          />
+        </Box>
       )}
       <Box
         sx={{

--- a/planningpoker-web/tests/session-labels-csv.spec.js
+++ b/planningpoker-web/tests/session-labels-csv.spec.js
@@ -268,17 +268,20 @@ test.describe('Consensus', () => {
 
       await expect(hostPage.getByText('Results')).toBeVisible({ timeout: 15000 })
 
-      // Host sees Consensus label + Select showing the value; non-host sees nothing
-      await expect(hostPage.getByText('Consensus:', { exact: true })).toBeVisible()
-      await expect(hostPage.getByRole('combobox')).toHaveText('5')
-      await expect(playerPage.getByText('Consensus:', { exact: true })).toHaveCount(0)
+      // Host sees the card-rail picker with "5" pre-selected (mode); non-host sees nothing
+      await expect(hostPage.getByText('Lock in the estimate')).toBeVisible()
+      await expect(hostPage.getByRole('button', { name: /^Set consensus to 5/ })).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      )
+      await expect(playerPage.getByText('Lock in the estimate')).toHaveCount(0)
     } finally {
       await hostCtx.close()
       await playerCtx.close()
     }
   })
 
-  test('host can override consensus via dropdown', async ({ browser }) => {
+  test('host can override consensus via card rail', async ({ browser }) => {
     const hostCtx = await browser.newContext()
     const playerCtx = await browser.newContext()
     try {
@@ -294,13 +297,17 @@ test.describe('Consensus', () => {
 
       await expect(hostPage.getByText('Results')).toBeVisible({ timeout: 15000 })
 
-      // Host opens consensus dropdown and picks a different value
-      const select = hostPage.locator('.MuiSelect-select')
-      await select.click()
-      await hostPage.getByRole('option', { name: '8', exact: true }).click()
+      // Mode picks '5' (alphabetical tiebreak); host clicks the '8' card to override
+      const fiveCard = hostPage.getByRole('button', { name: /^Set consensus to 5/ })
+      await expect(fiveCard).toHaveAttribute('aria-pressed', 'true')
+      await hostPage.getByRole('button', { name: /^Set consensus to 8/ }).click()
 
-      // Combobox should display the overridden value
-      await expect(hostPage.getByRole('combobox')).toHaveText('8')
+      // The overridden value should now be selected
+      await expect(hostPage.getByRole('button', { name: /^Set consensus to 8/ })).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      )
+      await expect(fiveCard).toHaveAttribute('aria-pressed', 'false')
     } finally {
       await hostCtx.close()
       await playerCtx.close()
@@ -592,7 +599,11 @@ test.describe('Accessibility announcements', () => {
       await playerPage.getByText('5', { exact: true }).click()
 
       await expect(hostPage.getByText('Results')).toBeVisible({ timeout: 15000 })
-      await expect(hostPage.getByRole('combobox')).toHaveText('5', { timeout: 10000 })
+      await expect(hostPage.getByRole('button', { name: /^Set consensus to 5/ })).toHaveAttribute(
+        'aria-pressed',
+        'true',
+        { timeout: 10000 },
+      )
 
       // Live region should contain consensus announcement (fires after 1500ms debounce)
       const liveRegion = hostPage.locator('[role="status"][aria-live="polite"]')


### PR DESCRIPTION
## Summary

Replaces the small MUI `<Select>` consensus dropdown with a **card-rail picker** (V3 from the design exploration at `claude.ai/design`):

- One mini card per legal value, using the voting-card visual language
- Voted cards raised with count badges
- Unvoted cards dimmed
- Mode pre-selected; selected card lifts with primary fill + white number
- Host sees where the team landed at a glance and locks in (or overrides) consensus in one click

New presentational component: `planningpoker-web/src/components/ConsensusCardRail.jsx`.

## Notes

- Supersedes #67 (closed when its base branch `chore/rename-round-label` was deleted after #66 merged).
- Two e2e tests that referenced the old combobox/dropdown were updated to assert on `aria-pressed` for the `Set consensus to X` buttons.

## Test plan

- [x] Vitest frontend unit tests (91/91)
- [x] Playwright e2e (40/40, including the two updated consensus tests)
- [x] Backend Gradle tests
- [x] Prettier + ESLint clean
- [x] Visual check in light + dark mode via Playwright screenshots