### PR TITLE
feat(ui): consensus card rail with bottom-aligned Suggested caption

### DIFF
--- a/planningpoker-web/src/components/ConsensusCardRail.jsx
+++ b/planningpoker-web/src/components/ConsensusCardRail.jsx
@@ -1,13 +1,7 @@
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 
-export default function ConsensusCardRail({
-  legalEstimates,
-  results,
-  autoConsensus,
-  value,
-  onChange,
-}) {
+export default function ConsensusCardRail({ legalEstimates, results, value, onChange }) {
   const counts = {}
   for (const { estimateValue } of results) {
     counts[estimateValue] = (counts[estimateValue] || 0) + 1
@@ -15,32 +9,12 @@ export default function ConsensusCardRail({
 
   return (
     <Box sx={{ minWidth: 0, pt: 1 }}>
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'baseline',
-          justifyContent: 'space-between',
-          gap: 1,
-          mb: 1,
-          flexWrap: 'wrap',
-        }}
+      <Typography
+        variant="body2"
+        sx={{ color: 'text.secondary', fontWeight: 500, fontSize: '0.8rem', mb: 1 }}
       >
-        <Typography
-          variant="body2"
-          sx={{ color: 'text.secondary', fontWeight: 500, fontSize: '0.8rem' }}
-        >
-          Lock in the estimate
-        </Typography>
-        {autoConsensus && (
-          <Typography variant="caption" sx={{ color: 'text.disabled', fontSize: '0.75rem' }}>
-            Suggested:{' '}
-            <Box component="strong" sx={{ color: 'text.primary' }}>
-              {autoConsensus}
-            </Box>{' '}
-            (mode)
-          </Typography>
-        )}
-      </Box>
+        Lock in the estimate
+      </Typography>
       <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap', pt: 0.75, pr: 0.75 }}>
         {legalEstimates.map((v) => {
           const n = counts[v] || 0

--- a/planningpoker-web/src/containers/Results.jsx
+++ b/planningpoker-web/src/containers/Results.jsx
@@ -54,48 +54,63 @@ export default function Results({ consensusOverride, setConsensusOverride }) {
 
   return (
     <Box>
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          minHeight: 42,
-          mb: currentLabel ? 1 : 2,
-          gap: 2,
-          flexWrap: 'wrap',
-        }}
-      >
-        <Typography variant="h6" sx={{ fontSize: '1.1rem' }}>
-          Results
-        </Typography>
-        {isAdmin && (
-          <Button
-            variant="contained"
-            size="large"
-            disableElevation
-            onClick={handleNextItem}
-            sx={{ px: 4 }}
-          >
-            Next Item
-          </Button>
-        )}
-      </Box>
+      <Typography variant="h6" sx={{ fontSize: '1.1rem', mb: currentLabel ? 1 : 2 }}>
+        Results
+      </Typography>
       {currentLabel && (
         <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
           {currentLabel}
         </Typography>
       )}
-      {isAdmin && displayConsensus && (
-        <Box sx={{ mb: 2.5 }}>
-          <ConsensusCardRail
-            legalEstimates={legalEstimates}
-            results={results}
-            autoConsensus={autoConsensus}
-            value={displayConsensus}
-            onChange={(v) => {
-              setConsensusOverride(v === autoConsensus ? null : v)
+      {isAdmin && (
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: { xs: '1fr', md: '1fr 240px' },
+            gap: 3,
+            alignItems: 'end',
+            mb: 2.5,
+          }}
+        >
+          <Box sx={{ minWidth: 0 }}>
+            {displayConsensus && (
+              <ConsensusCardRail
+                legalEstimates={legalEstimates}
+                results={results}
+                value={displayConsensus}
+                onChange={(v) => {
+                  setConsensusOverride(v === autoConsensus ? null : v)
+                }}
+              />
+            )}
+          </Box>
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: { xs: 'stretch', md: 'flex-end' },
+              gap: 1,
             }}
-          />
+          >
+            <Button
+              variant="contained"
+              size="large"
+              disableElevation
+              onClick={handleNextItem}
+              sx={{ px: 4, alignSelf: { xs: 'stretch', md: 'flex-end' } }}
+            >
+              Next Item
+            </Button>
+            {autoConsensus && (
+              <Typography variant="caption" sx={{ color: 'text.disabled', fontSize: '0.75rem' }}>
+                Suggested:{' '}
+                <Box component="strong" sx={{ color: 'text.primary' }}>
+                  {autoConsensus}
+                </Box>{' '}
+                (mode)
+              </Typography>
+            )}
+          </Box>
         </Box>
       )}
       <Box


### PR DESCRIPTION
## Summary
- Replace consensus dropdown with a card-rail picker: admin taps a card to lock in / override the round's estimate, with a vote-count badge and mode-suggestion preserved.
- Move \`Next Item\` button and \`Suggested: X (mode)\` caption into a right-hand column aligned to the bottom of the card rail, so the caption's bottom sits flush with the rail's bottom.
- Cards wrap within the chart's width (\`1fr\` column of the results grid) so large custom schemes no longer extend past the chart.

## Test plan
- [x] \`npm run lint\` + prettier check
- [x] \`npx vitest run\` (91 unit tests)
- [x] \`./gradlew planningpoker-api:test\` + \`spotlessCheck\`
- [x] \`npx playwright test\` (41 e2e tests)
- [x] Manual UAT via Playwright: Fibonacci (6 cards) and Custom (20 cards) both render correctly with Suggested caption bottom aligned to card rail bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)