### PR TITLE
feat(ui): round eyebrow + disclosure footer on results panel

### DIFF
--- a/planningpoker-web/src/containers/Results.jsx
+++ b/planningpoker-web/src/containers/Results.jsx
@@ -1,14 +1,20 @@
+import { useState } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import Button from '@mui/material/Button'
 import DownloadIcon from '@mui/icons-material/Download'
+import ChevronRightIcon from '@mui/icons-material/ChevronRight'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import ResultsTable from './ResultsTable'
 import ResultsChart from './ResultsChart'
 import ConsensusCardRail from '../components/ConsensusCardRail'
 import { resetSession, roundCompleted } from '../actions'
 import { calcConsensus } from '../utils/consensus'
 import { generateCsv, downloadCsv } from '../utils/csvExport'
+
+const fmtTime = (iso) =>
+  new Date(iso).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
 
 export default function Results({ consensusOverride, setConsensusOverride }) {
   const dispatch = useDispatch()
@@ -20,10 +26,12 @@ export default function Results({ consensusOverride, setConsensusOverride }) {
   const rounds = useSelector((state) => state.rounds)
   const users = useSelector((state) => state.users)
   const legalEstimates = useSelector((state) => state.game.legalEstimates)
+  const [historyOpen, setHistoryOpen] = useState(false)
 
   const autoConsensus = calcConsensus(results)
   const displayConsensus = consensusOverride || autoConsensus
   const totalRounds = rounds.length + (results.length > 0 ? 1 : 0)
+  const hasAnyHistory = rounds.length > 0 || results.length > 0
 
   const handleNextItem = () => {
     const round = {
@@ -57,34 +65,56 @@ export default function Results({ consensusOverride, setConsensusOverride }) {
       <Box
         sx={{
           display: 'flex',
-          alignItems: 'center',
+          alignItems: 'flex-start',
           justifyContent: 'space-between',
           minHeight: 42,
-          mb: currentLabel ? 1 : 2,
+          mb: 2,
           gap: 2,
           flexWrap: 'wrap',
         }}
       >
-        <Typography variant="h6" sx={{ fontSize: '1.1rem' }}>
-          Results
-        </Typography>
+        <Box sx={{ minWidth: 0, flex: '1 1 auto' }}>
+          <Typography
+            component="h2"
+            sx={{
+              fontSize: '0.6875rem',
+              fontWeight: 600,
+              letterSpacing: '0.1em',
+              textTransform: 'uppercase',
+              color: 'primary.main',
+              mb: 0.5,
+            }}
+          >
+            {totalRounds > 0 ? `Round ${totalRounds}` : 'Results'}
+            {results.length > 0 && ' · Revealed'}
+          </Typography>
+          {currentLabel && (
+            <Typography
+              sx={{
+                fontSize: '1.25rem',
+                fontWeight: 600,
+                letterSpacing: '-0.01em',
+                color: 'text.primary',
+                lineHeight: 1.3,
+                wordBreak: 'break-word',
+              }}
+            >
+              {currentLabel}
+            </Typography>
+          )}
+        </Box>
         {isAdmin && (
           <Button
             variant="contained"
             size="large"
             disableElevation
             onClick={handleNextItem}
-            sx={{ px: 4 }}
+            sx={{ px: 4, flexShrink: 0 }}
           >
             Next Item
           </Button>
         )}
       </Box>
-      {currentLabel && (
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          {currentLabel}
-        </Typography>
-      )}
       {isAdmin && displayConsensus && (
         <Box sx={{ mb: 2.5 }}>
           <ConsensusCardRail
@@ -121,40 +151,136 @@ export default function Results({ consensusOverride, setConsensusOverride }) {
         </Box>
         <ResultsTable />
       </Box>
-      {isAdmin && (rounds.length > 0 || results.length > 0) && (
-        <Box
-          sx={{
-            mt: 2,
-            pt: 2,
-            borderTop: '1px solid',
-            borderColor: 'divider',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            gap: 2,
-            flexWrap: 'wrap',
-          }}
-        >
-          <Typography
-            variant="caption"
-            color="text.secondary"
+      {hasAnyHistory && (
+        <Box sx={{ mt: 2.5 }}>
+          <Box
             sx={{
-              letterSpacing: '0.08em',
-              textTransform: 'uppercase',
-              fontSize: '0.7rem',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 2,
+              flexWrap: 'wrap',
+              px: 1.75,
+              py: 1.25,
+              border: '1px solid',
+              borderColor: 'divider',
+              borderRadius: 1,
+              bgcolor: 'background.paper',
             }}
           >
-            Session history · {totalRounds} {totalRounds === 1 ? 'round' : 'rounds'}
-          </Typography>
-          <Button
-            variant="outlined"
-            size="small"
-            startIcon={<DownloadIcon />}
-            onClick={handleExportCsv}
-            disabled={rounds.length === 0 && results.length === 0}
-          >
-            Export CSV
-          </Button>
+            {rounds.length > 0 ? (
+              <Button
+                variant="text"
+                onClick={() => setHistoryOpen((v) => !v)}
+                aria-expanded={historyOpen}
+                startIcon={historyOpen ? <ExpandMoreIcon /> : <ChevronRightIcon />}
+                sx={{
+                  color: 'text.primary',
+                  fontSize: '0.8125rem',
+                  fontWeight: 600,
+                  p: 0,
+                  minWidth: 0,
+                  '&:hover': { bgcolor: 'transparent' },
+                  '& .MuiButton-startIcon': { mr: 0.75 },
+                }}
+              >
+                {historyOpen ? 'Hide' : 'Show'} session history
+                <Box component="span" sx={{ color: 'text.disabled', fontWeight: 500, ml: 0.75 }}>
+                  · {rounds.length} completed {rounds.length === 1 ? 'round' : 'rounds'}
+                </Box>
+              </Button>
+            ) : (
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{
+                  letterSpacing: '0.08em',
+                  textTransform: 'uppercase',
+                  fontSize: '0.7rem',
+                }}
+              >
+                Session history · {totalRounds} {totalRounds === 1 ? 'round' : 'rounds'}
+              </Typography>
+            )}
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<DownloadIcon />}
+              onClick={handleExportCsv}
+            >
+              Export CSV
+            </Button>
+          </Box>
+          {historyOpen && rounds.length > 0 && (
+            <Box
+              sx={{
+                mt: 1,
+                border: '1px solid',
+                borderColor: 'divider',
+                borderRadius: 1,
+                bgcolor: 'background.paper',
+                overflow: 'hidden',
+              }}
+            >
+              {rounds.map((r, i) => (
+                <Box
+                  key={i}
+                  sx={{
+                    display: 'grid',
+                    gridTemplateColumns: 'auto 1fr auto auto',
+                    alignItems: 'center',
+                    gap: 1.5,
+                    px: 1.75,
+                    py: 1.25,
+                    borderTop: i === 0 ? 'none' : '1px solid',
+                    borderColor: 'divider',
+                  }}
+                >
+                  <Typography
+                    sx={{
+                      color: 'text.disabled',
+                      fontSize: '0.6875rem',
+                      fontWeight: 700,
+                      fontVariantNumeric: 'tabular-nums',
+                      minWidth: 24,
+                    }}
+                  >
+                    #{i + 1}
+                  </Typography>
+                  <Typography
+                    sx={{
+                      color: 'text.primary',
+                      fontSize: '0.8125rem',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {r.label || <em>No label</em>}
+                  </Typography>
+                  <Typography sx={{ color: 'text.disabled', fontSize: '0.6875rem' }}>
+                    {fmtTime(r.timestamp)}
+                  </Typography>
+                  <Box
+                    sx={{
+                      px: 1,
+                      py: 0.25,
+                      borderRadius: 0.75,
+                      bgcolor: 'action.hover',
+                      color: 'text.primary',
+                      fontSize: '0.8125rem',
+                      fontWeight: 700,
+                      fontVariantNumeric: 'tabular-nums',
+                      textAlign: 'center',
+                      minWidth: 28,
+                    }}
+                  >
+                    {r.consensus}
+                  </Box>
+                </Box>
+              ))}
+            </Box>
+          )}
         </Box>
       )}
     </Box>

--- a/planningpoker-web/tests/epoch-flicker.spec.js
+++ b/planningpoker-web/tests/epoch-flicker.spec.js
@@ -34,8 +34,8 @@ test.describe('Epoch-based messaging — race conditions', () => {
       await hostPage.getByText(hostVote, { exact: true }).click()
       await playerPage.getByText(playerVote, { exact: true }).click()
 
-      await expect(hostPage.getByText('Results')).toBeVisible({ timeout: 15000 })
-      await expect(playerPage.getByText('Results')).toBeVisible({ timeout: 15000 })
+      await expect(hostPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
+      await expect(playerPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
 
       await hostPage.getByRole('button', { name: 'Next Item' }).click()
       await expect(hostPage.getByText('Cast your estimate')).toBeVisible({ timeout: 10000 })
@@ -57,8 +57,8 @@ test.describe('Epoch-based messaging — race conditions', () => {
 
     await hostPage.getByText('3', { exact: true }).click()
     await playerPage.getByText('3', { exact: true }).click()
-    await expect(hostPage.getByText('Results')).toBeVisible({ timeout: 15000 })
-    await expect(playerPage.getByText('Results')).toBeVisible({ timeout: 15000 })
+    await expect(hostPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
+    await expect(playerPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
 
     await hostPage.getByRole('button', { name: 'Next Item' }).click()
     await expect(playerPage.getByText('Cast your estimate')).toBeVisible({ timeout: 10000 })
@@ -66,8 +66,8 @@ test.describe('Epoch-based messaging — race conditions', () => {
 
     await playerPage.getByText('8', { exact: true }).click()
     await hostPage.getByText('8', { exact: true }).click()
-    await expect(hostPage.getByText('Results')).toBeVisible({ timeout: 15000 })
-    await expect(playerPage.getByText('Results')).toBeVisible({ timeout: 15000 })
+    await expect(hostPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
+    await expect(playerPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
 
     await hostCtx.close()
     await playerCtx.close()
@@ -85,15 +85,15 @@ test.describe('Epoch-based messaging — race conditions', () => {
     await hostPage.getByText('5', { exact: true }).click()
     await playerPage.getByText('8', { exact: true }).click()
 
-    await expect(hostPage.getByText('Results')).toBeVisible({ timeout: 15000 })
-    await expect(playerPage.getByText('Results')).toBeVisible({ timeout: 15000 })
+    await expect(hostPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
+    await expect(playerPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
 
     await playerPage.getByRole('button', { name: /Bob/i }).click()
     await playerPage.getByRole('menuitem', { name: 'Log out' }).click()
     await expect(playerPage).toHaveURL('/')
 
     // Host remains in Results view — Bob is gone but Alice's vote persists.
-    await expect(hostPage.getByText('Results')).toBeVisible({ timeout: 5000 })
+    await expect(hostPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 5000 })
     await expect(hostPage.getByText('Cast your estimate')).not.toBeVisible()
 
     await hostCtx.close()

--- a/planningpoker-web/tests/planning-poker.spec.js
+++ b/planningpoker-web/tests/planning-poker.spec.js
@@ -1,398 +1,397 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '@playwright/test'
 
 test.describe('Welcome Page', () => {
   test('shows join and host buttons', async ({ page }) => {
-    await page.goto('/');
-    await expect(page.locator('h3')).toHaveText('Planning Poker');
-    await expect(page.getByRole('link', { name: 'Join Game' })).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Host New Game' })).toBeVisible();
-  });
+    await page.goto('/')
+    await expect(page.locator('h3')).toHaveText('Planning Poker')
+    await expect(page.getByRole('link', { name: 'Join Game' })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Host New Game' })).toBeVisible()
+  })
 
   test('navigates to host page', async ({ page }) => {
-    await page.goto('/');
-    await page.getByRole('link', { name: 'Host New Game' }).click();
-    await expect(page).toHaveURL('/host');
-    await expect(page.getByRole('heading', { name: 'Host a Game' })).toBeVisible();
-  });
+    await page.goto('/')
+    await page.getByRole('link', { name: 'Host New Game' }).click()
+    await expect(page).toHaveURL('/host')
+    await expect(page.getByRole('heading', { name: 'Host a Game' })).toBeVisible()
+  })
 
   test('navigates to join page', async ({ page }) => {
-    await page.goto('/');
-    await page.getByRole('link', { name: 'Join Game' }).click();
-    await expect(page).toHaveURL('/join');
-    await expect(page.getByRole('heading', { name: 'Join a Game' })).toBeVisible();
-  });
-});
+    await page.goto('/')
+    await page.getByRole('link', { name: 'Join Game' }).click()
+    await expect(page).toHaveURL('/join')
+    await expect(page.getByRole('heading', { name: 'Join a Game' })).toBeVisible()
+  })
+})
 
 test.describe('Host a Game', () => {
   test('creates a session and shows vote cards', async ({ page }) => {
-    await page.goto('/host');
-    await page.getByLabel('Your Name').fill('Alice');
-    await page.getByRole('button', { name: 'Start Game' }).click();
+    await page.goto('/host')
+    await page.getByLabel('Your Name').fill('Alice')
+    await page.getByRole('button', { name: 'Start Game' }).click()
 
-    await expect(page).toHaveURL('/game');
-    await expect(page.getByText('Cast your estimate')).toBeVisible();
-    await expect(page.getByText('1', { exact: true })).toBeVisible();
-    await expect(page.getByText('13', { exact: true })).toBeVisible();
-  });
+    await expect(page).toHaveURL('/game')
+    await expect(page.getByText('Cast your estimate')).toBeVisible()
+    await expect(page.getByText('1', { exact: true })).toBeVisible()
+    await expect(page.getByText('13', { exact: true })).toBeVisible()
+  })
 
   test('shows session ID in header after creating game', async ({ page }) => {
-    await page.goto('/host');
-    await page.getByLabel('Your Name').fill('Alice');
-    await page.getByRole('button', { name: 'Start Game' }).click();
-    await expect(page).toHaveURL('/game');
+    await page.goto('/host')
+    await page.getByLabel('Your Name').fill('Alice')
+    await page.getByRole('button', { name: 'Start Game' }).click()
+    await expect(page).toHaveURL('/game')
 
-    await expect(page.locator('.MuiChip-label')).toHaveText(/^Session ID: [a-f0-9]{8}$/);
-  });
+    await expect(page.locator('.MuiChip-label')).toHaveText(/^Session ID: [a-f0-9]{8}$/)
+  })
 
   test('host can vote and see results', async ({ page }) => {
-    await page.goto('/host');
-    await page.getByLabel('Your Name').fill('Alice');
-    await page.getByRole('button', { name: 'Start Game' }).click();
-    await expect(page).toHaveURL('/game');
+    await page.goto('/host')
+    await page.getByLabel('Your Name').fill('Alice')
+    await page.getByRole('button', { name: 'Start Game' }).click()
+    await expect(page).toHaveURL('/game')
 
-    await expect(page.getByText('Cast your estimate')).toBeVisible();
-    await page.getByText('5', { exact: true }).click();
+    await expect(page.getByText('Cast your estimate')).toBeVisible()
+    await page.getByText('5', { exact: true }).click()
 
-    await expect(page.getByText('Results')).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Next Item' })).toBeVisible();
-  });
+    await expect(page.getByText(/^Round \d+/)).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Next Item' })).toBeVisible()
+  })
 
   test('host sees Next Item button after voting', async ({ page }) => {
-    await page.goto('/host');
-    await page.getByLabel('Your Name').fill('Alice');
-    await page.getByRole('button', { name: 'Start Game' }).click();
-    await expect(page).toHaveURL('/game');
+    await page.goto('/host')
+    await page.getByLabel('Your Name').fill('Alice')
+    await page.getByRole('button', { name: 'Start Game' }).click()
+    await expect(page).toHaveURL('/game')
 
-    await expect(page.getByText('Cast your estimate')).toBeVisible();
-    await page.getByText('5', { exact: true }).click();
-    await expect(page.getByText('Results')).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Next Item' })).toBeVisible();
-  });
-});
+    await expect(page.getByText('Cast your estimate')).toBeVisible()
+    await page.getByText('5', { exact: true }).click()
+    await expect(page.getByText(/^Round \d+/)).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Next Item' })).toBeVisible()
+  })
+})
 
 test.describe('Join a Game', () => {
   test('requires name and session ID', async ({ page }) => {
-    await page.goto('/join');
-    await expect(page.getByLabel('Your Name')).toBeVisible();
-    await expect(page.getByLabel('Session ID')).toBeVisible();
-  });
+    await page.goto('/join')
+    await expect(page.getByLabel('Your Name')).toBeVisible()
+    await expect(page.getByLabel('Session ID')).toBeVisible()
+  })
 
   test('redirects to home if accessing /game without session', async ({ page }) => {
-    await page.goto('/game');
-    await expect(page).toHaveURL('/');
-  });
-});
+    await page.goto('/game')
+    await expect(page).toHaveURL('/')
+  })
+})
 
 test.describe('Logout', () => {
   test('log out returns to welcome page', async ({ page }) => {
-    await page.goto('/host');
-    await page.getByLabel('Your Name').fill('Alice');
-    await page.getByRole('button', { name: 'Start Game' }).click();
-    await expect(page).toHaveURL('/game');
+    await page.goto('/host')
+    await page.getByLabel('Your Name').fill('Alice')
+    await page.getByRole('button', { name: 'Start Game' }).click()
+    await expect(page).toHaveURL('/game')
 
-    await page.getByRole('button', { name: /Alice/i }).click();
-    await page.getByRole('menuitem', { name: 'Log out' }).click();
-    await expect(page).toHaveURL('/');
-  });
-});
+    await page.getByRole('button', { name: /Alice/i }).click()
+    await page.getByRole('menuitem', { name: 'Log out' }).click()
+    await expect(page).toHaveURL('/')
+  })
+})
 
 test.describe('Dark/Light Mode', () => {
   test('toggle switches between dark and light mode', async ({ page }) => {
-    await page.emulateMedia({ colorScheme: 'dark' });
-    await page.goto('/');
-    await page.evaluate(() => localStorage.removeItem('pp-theme'));
-    await page.reload();
+    await page.emulateMedia({ colorScheme: 'dark' })
+    await page.goto('/')
+    await page.evaluate(() => localStorage.removeItem('pp-theme'))
+    await page.reload()
 
-    const DARK_BG = 'rgb(18, 18, 18)';
-    const LIGHT_BG = 'rgb(248, 250, 252)';
-    const toggle = page.getByRole('button', { name: 'Toggle dark mode' });
+    const DARK_BG = 'rgb(18, 18, 18)'
+    const LIGHT_BG = 'rgb(248, 250, 252)'
+    const toggle = page.getByRole('button', { name: 'Toggle dark mode' })
 
     // Default with dark OS preference is dark mode
     await page.waitForFunction(
       (expected) => getComputedStyle(document.body).backgroundColor === expected,
       DARK_BG,
-    );
+    )
 
     // Toggle to light mode
-    await toggle.click();
+    await toggle.click()
     await page.waitForFunction(
       (expected) => getComputedStyle(document.body).backgroundColor === expected,
       LIGHT_BG,
-    );
+    )
 
     // Toggle back to dark mode
-    await toggle.click();
+    await toggle.click()
     await page.waitForFunction(
       (expected) => getComputedStyle(document.body).backgroundColor === expected,
       DARK_BG,
-    );
-  });
-});
+    )
+  })
+})
 
 // Helper to create a session and return the session ID
 async function hostGame(page, name) {
-  await page.goto('/host');
-  await page.getByLabel('Your Name').fill(name);
-  await page.getByRole('button', { name: 'Start Game' }).click();
-  await expect(page).toHaveURL('/game');
-  const chipText = await page.locator('.MuiChip-label').textContent();
-  return chipText.replace(/^Session ID:\s*/, '');
+  await page.goto('/host')
+  await page.getByLabel('Your Name').fill(name)
+  await page.getByRole('button', { name: 'Start Game' }).click()
+  await expect(page).toHaveURL('/game')
+  const chipText = await page.locator('.MuiChip-label').textContent()
+  return chipText.replace(/^Session ID:\s*/, '')
 }
 
 // Helper to join a session
 async function joinGame(page, name, sessionId) {
-  await page.goto('/join');
-  await page.getByLabel('Your Name').fill(name);
-  await page.getByLabel('Session ID').fill(sessionId);
-  await page.getByRole('button', { name: 'Join Game' }).click();
-  await expect(page).toHaveURL('/game');
+  await page.goto('/join')
+  await page.getByLabel('Your Name').fill(name)
+  await page.getByLabel('Session ID').fill(sessionId)
+  await page.getByRole('button', { name: 'Join Game' }).click()
+  await expect(page).toHaveURL('/game')
 }
 
 test.describe('Multi-User Flows', () => {
   test('two users can join the same session and both vote', async ({ browser }) => {
-    const hostCtx = await browser.newContext();
-    const hostPage = await hostCtx.newPage();
-    const sessionId = await hostGame(hostPage, 'Alice');
+    const hostCtx = await browser.newContext()
+    const hostPage = await hostCtx.newPage()
+    const sessionId = await hostGame(hostPage, 'Alice')
 
-    const playerCtx = await browser.newContext();
-    const playerPage = await playerCtx.newPage();
-    await joinGame(playerPage, 'Bob', sessionId);
+    const playerCtx = await browser.newContext()
+    const playerPage = await playerCtx.newPage()
+    await joinGame(playerPage, 'Bob', sessionId)
 
     // Both should see vote cards
-    await expect(hostPage.getByText('Cast your estimate')).toBeVisible();
-    await expect(playerPage.getByText('Cast your estimate')).toBeVisible();
+    await expect(hostPage.getByText('Cast your estimate')).toBeVisible()
+    await expect(playerPage.getByText('Cast your estimate')).toBeVisible()
 
     // Both vote
-    await hostPage.getByText('8', { exact: true }).click();
-    await playerPage.getByText('5', { exact: true }).click();
+    await hostPage.getByText('8', { exact: true }).click()
+    await playerPage.getByText('5', { exact: true }).click()
 
     // Both should see results (via WebSocket broadcast)
-    await expect(hostPage.getByText('Results')).toBeVisible({ timeout: 15000 });
-    await expect(playerPage.getByText('Results')).toBeVisible({ timeout: 15000 });
+    await expect(hostPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
+    await expect(playerPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
 
     // Only host sees Next Item
-    await expect(hostPage.getByRole('button', { name: 'Next Item' })).toBeVisible();
-    await expect(playerPage.getByRole('button', { name: 'Next Item' })).not.toBeVisible();
+    await expect(hostPage.getByRole('button', { name: 'Next Item' })).toBeVisible()
+    await expect(playerPage.getByRole('button', { name: 'Next Item' })).not.toBeVisible()
 
-    await hostCtx.close();
-    await playerCtx.close();
-  });
+    await hostCtx.close()
+    await playerCtx.close()
+  })
 
   test('self-initiated logout does not show kicked toast', async ({ browser }) => {
-    const hostCtx = await browser.newContext();
-    const hostPage = await hostCtx.newPage();
-    const sessionId = await hostGame(hostPage, 'Alice');
+    const hostCtx = await browser.newContext()
+    const hostPage = await hostCtx.newPage()
+    const sessionId = await hostGame(hostPage, 'Alice')
 
-    const playerCtx = await browser.newContext();
-    const playerPage = await playerCtx.newPage();
-    await joinGame(playerPage, 'Bob', sessionId);
+    const playerCtx = await browser.newContext()
+    const playerPage = await playerCtx.newPage()
+    await joinGame(playerPage, 'Bob', sessionId)
 
     // Wait until both clients have finished subscribing
     await expect(hostPage.getByRole('main').getByText('Bob', { exact: true })).toBeVisible({
       timeout: 10000,
-    });
+    })
 
     // Deterministically reproduce the race: hold the /logout response client-side
     // for 800ms so the server-side USERS_MESSAGE broadcast always arrives first.
     await playerPage.route('**/logout', async (route) => {
-      await new Promise((r) => setTimeout(r, 800));
-      await route.continue();
-    });
+      await new Promise((r) => setTimeout(r, 800))
+      await route.continue()
+    })
 
     // Bob logs himself out
-    await playerPage.getByRole('button', { name: /Bob/i }).click();
-    await playerPage.getByRole('menuitem', { name: 'Log out' }).click();
-    await expect(playerPage).toHaveURL('/');
+    await playerPage.getByRole('button', { name: /Bob/i }).click()
+    await playerPage.getByRole('menuitem', { name: 'Log out' }).click()
+    await expect(playerPage).toHaveURL('/')
 
     // No "removed by the host" toast should appear, immediately or after a beat
-    await expect(
-      playerPage.getByText(/removed from the session by the host/i),
-    ).not.toBeVisible();
-    await playerPage.waitForTimeout(500);
-    await expect(
-      playerPage.getByText(/removed from the session by the host/i),
-    ).not.toBeVisible();
+    await expect(playerPage.getByText(/removed from the session by the host/i)).not.toBeVisible()
+    await playerPage.waitForTimeout(500)
+    await expect(playerPage.getByText(/removed from the session by the host/i)).not.toBeVisible()
 
-    await hostCtx.close();
-    await playerCtx.close();
-  });
+    await hostCtx.close()
+    await playerCtx.close()
+  })
 
   test('host is visible in joiner players list in round 1 before any voting', async ({
     browser,
   }) => {
-    const hostCtx = await browser.newContext();
-    const hostPage = await hostCtx.newPage();
-    const sessionId = await hostGame(hostPage, 'Alice');
+    const hostCtx = await browser.newContext()
+    const hostPage = await hostCtx.newPage()
+    const sessionId = await hostGame(hostPage, 'Alice')
 
-    const playerCtx = await browser.newContext();
-    const playerPage = await playerCtx.newPage();
-    await joinGame(playerPage, 'Bob', sessionId);
+    const playerCtx = await browser.newContext()
+    const playerPage = await playerCtx.newPage()
+    await joinGame(playerPage, 'Bob', sessionId)
 
     // Round 1, no votes cast: joiner must see the host in the Players list
-    const joinerPlayers = playerPage.getByRole('main').getByText('Alice', { exact: true });
-    await expect(joinerPlayers).toBeVisible({ timeout: 10000 });
+    const joinerPlayers = playerPage.getByRole('main').getByText('Alice', { exact: true })
+    await expect(joinerPlayers).toBeVisible({ timeout: 10000 })
 
     // And the host must also see the joiner in the Players list
-    const hostPlayers = hostPage.getByRole('main').getByText('Bob', { exact: true });
-    await expect(hostPlayers).toBeVisible({ timeout: 10000 });
+    const hostPlayers = hostPage.getByRole('main').getByText('Bob', { exact: true })
+    await expect(hostPlayers).toBeVisible({ timeout: 10000 })
 
-    await hostCtx.close();
-    await playerCtx.close();
-  });
+    await hostCtx.close()
+    await playerCtx.close()
+  })
 
   test('non-host does not see Next Item button', async ({ browser }) => {
-    const hostCtx = await browser.newContext();
-    const hostPage = await hostCtx.newPage();
-    const sessionId = await hostGame(hostPage, 'Alice');
+    const hostCtx = await browser.newContext()
+    const hostPage = await hostCtx.newPage()
+    const sessionId = await hostGame(hostPage, 'Alice')
 
-    const playerCtx = await browser.newContext();
-    const playerPage = await playerCtx.newPage();
-    await joinGame(playerPage, 'Bob', sessionId);
+    const playerCtx = await browser.newContext()
+    const playerPage = await playerCtx.newPage()
+    await joinGame(playerPage, 'Bob', sessionId)
 
     // Both vote
-    await hostPage.getByText('3', { exact: true }).click();
-    await playerPage.getByText('3', { exact: true }).click();
+    await hostPage.getByText('3', { exact: true }).click()
+    await playerPage.getByText('3', { exact: true }).click()
 
     // Wait for results
-    await expect(hostPage.getByText('Results')).toBeVisible({ timeout: 15000 });
-    await expect(playerPage.getByText('Results')).toBeVisible({ timeout: 15000 });
+    await expect(hostPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
+    await expect(playerPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
 
     // Only host sees Next Item
-    await expect(hostPage.getByRole('button', { name: 'Next Item' })).toBeVisible();
-    await expect(playerPage.getByRole('button', { name: 'Next Item' })).not.toBeVisible();
+    await expect(hostPage.getByRole('button', { name: 'Next Item' })).toBeVisible()
+    await expect(playerPage.getByRole('button', { name: 'Next Item' })).not.toBeVisible()
 
-    await hostCtx.close();
-    await playerCtx.close();
-  });
+    await hostCtx.close()
+    await playerCtx.close()
+  })
 
   test('host clicking Next Item returns non-host to voting screen', async ({ browser }) => {
-    const hostCtx = await browser.newContext();
-    const hostPage = await hostCtx.newPage();
-    const sessionId = await hostGame(hostPage, 'Alice');
+    const hostCtx = await browser.newContext()
+    const hostPage = await hostCtx.newPage()
+    const sessionId = await hostGame(hostPage, 'Alice')
 
-    const playerCtx = await browser.newContext();
-    const playerPage = await playerCtx.newPage();
-    await joinGame(playerPage, 'Bob', sessionId);
+    const playerCtx = await browser.newContext()
+    const playerPage = await playerCtx.newPage()
+    await joinGame(playerPage, 'Bob', sessionId)
 
     // Both vote
-    await hostPage.getByText('5', { exact: true }).click();
-    await playerPage.getByText('8', { exact: true }).click();
+    await hostPage.getByText('5', { exact: true }).click()
+    await playerPage.getByText('8', { exact: true }).click()
 
     // Both see results
-    await expect(hostPage.getByText('Results')).toBeVisible({ timeout: 15000 });
-    await expect(playerPage.getByText('Results')).toBeVisible({ timeout: 15000 });
+    await expect(hostPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
+    await expect(playerPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
 
     // Host clicks Next Item
-    await hostPage.getByRole('button', { name: 'Next Item' }).click();
+    await hostPage.getByRole('button', { name: 'Next Item' }).click()
 
     // Both should return to voting screen
-    await expect(hostPage.getByText('Cast your estimate')).toBeVisible({ timeout: 10000 });
-    await expect(playerPage.getByText('Cast your estimate')).toBeVisible({ timeout: 10000 });
+    await expect(hostPage.getByText('Cast your estimate')).toBeVisible({ timeout: 10000 })
+    await expect(playerPage.getByText('Cast your estimate')).toBeVisible({ timeout: 10000 })
 
-    await hostCtx.close();
-    await playerCtx.close();
-  });
+    await hostCtx.close()
+    await playerCtx.close()
+  })
 
   test('three users vote and all see results', async ({ browser }) => {
-    const hostCtx = await browser.newContext();
-    const hostPage = await hostCtx.newPage();
-    const sessionId = await hostGame(hostPage, 'Alice');
+    const hostCtx = await browser.newContext()
+    const hostPage = await hostCtx.newPage()
+    const sessionId = await hostGame(hostPage, 'Alice')
 
-    const p2Ctx = await browser.newContext();
-    const p2Page = await p2Ctx.newPage();
-    await joinGame(p2Page, 'Bob', sessionId);
+    const p2Ctx = await browser.newContext()
+    const p2Page = await p2Ctx.newPage()
+    await joinGame(p2Page, 'Bob', sessionId)
 
-    const p3Ctx = await browser.newContext();
-    const p3Page = await p3Ctx.newPage();
-    await joinGame(p3Page, 'Charlie', sessionId);
+    const p3Ctx = await browser.newContext()
+    const p3Page = await p3Ctx.newPage()
+    await joinGame(p3Page, 'Charlie', sessionId)
 
     // All vote (stagger slightly to avoid race)
-    await hostPage.getByText('5', { exact: true }).click();
-    await p2Page.getByText('8', { exact: true }).click();
-    await p3Page.getByText('5', { exact: true }).click();
+    await hostPage.getByText('5', { exact: true }).click()
+    await p2Page.getByText('8', { exact: true }).click()
+    await p3Page.getByText('5', { exact: true }).click()
 
     // All see results
-    await expect(hostPage.getByText('Results')).toBeVisible({ timeout: 15000 });
-    await expect(p2Page.getByText('Results')).toBeVisible({ timeout: 15000 });
-    await expect(p3Page.getByText('Results')).toBeVisible({ timeout: 15000 });
+    await expect(hostPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
+    await expect(p2Page.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
+    await expect(p3Page.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
 
-    await hostCtx.close();
-    await p2Ctx.close();
-    await p3Ctx.close();
-  });
-});
+    await hostCtx.close()
+    await p2Ctx.close()
+    await p3Ctx.close()
+  })
+})
 
 test.describe('Estimation Schemes', () => {
   test('T-shirt scheme shows correct cards', async ({ page }) => {
-    await page.goto('/host');
-    await page.getByLabel('Your Name').fill('Alice');
-    await page.getByTestId('scheme-tile-tshirt').click();
-    await page.getByRole('button', { name: 'Start Game' }).click();
+    await page.goto('/host')
+    await page.getByLabel('Your Name').fill('Alice')
+    await page.getByTestId('scheme-tile-tshirt').click()
+    await page.getByRole('button', { name: 'Start Game' }).click()
 
-    await expect(page).toHaveURL('/game');
-    await expect(page.getByText('XS', { exact: true })).toBeVisible();
-    await expect(page.getByText('S', { exact: true })).toBeVisible();
-    await expect(page.getByText('M', { exact: true })).toBeVisible();
-    await expect(page.getByText('L', { exact: true })).toBeVisible();
-    await expect(page.getByText('XL', { exact: true })).toBeVisible();
-    await expect(page.getByText('XXL', { exact: true })).toBeVisible();
-    await expect(page.getByText('13', { exact: true })).not.toBeVisible();
-  });
+    await expect(page).toHaveURL('/game')
+    await expect(page.getByText('XS', { exact: true })).toBeVisible()
+    await expect(page.getByText('S', { exact: true })).toBeVisible()
+    await expect(page.getByText('M', { exact: true })).toBeVisible()
+    await expect(page.getByText('L', { exact: true })).toBeVisible()
+    await expect(page.getByText('XL', { exact: true })).toBeVisible()
+    await expect(page.getByText('XXL', { exact: true })).toBeVisible()
+    await expect(page.getByText('13', { exact: true })).not.toBeVisible()
+  })
 
   test('Simple scheme shows correct cards', async ({ page }) => {
-    await page.goto('/host');
-    await page.getByLabel('Your Name').fill('Alice');
-    await page.getByTestId('scheme-tile-simple').click();
-    await page.getByRole('button', { name: 'Start Game' }).click();
+    await page.goto('/host')
+    await page.getByLabel('Your Name').fill('Alice')
+    await page.getByTestId('scheme-tile-simple').click()
+    await page.getByRole('button', { name: 'Start Game' }).click()
 
-    await expect(page).toHaveURL('/game');
-    await expect(page.getByText('1', { exact: true })).toBeVisible();
-    await expect(page.getByText('2', { exact: true })).toBeVisible();
-    await expect(page.getByText('3', { exact: true })).toBeVisible();
-    await expect(page.getByText('4', { exact: true })).toBeVisible();
-    await expect(page.getByText('5', { exact: true })).toBeVisible();
-    await expect(page.getByText('13', { exact: true })).not.toBeVisible();
-  });
+    await expect(page).toHaveURL('/game')
+    await expect(page.getByText('1', { exact: true })).toBeVisible()
+    await expect(page.getByText('2', { exact: true })).toBeVisible()
+    await expect(page.getByText('3', { exact: true })).toBeVisible()
+    await expect(page.getByText('4', { exact: true })).toBeVisible()
+    await expect(page.getByText('5', { exact: true })).toBeVisible()
+    await expect(page.getByText('13', { exact: true })).not.toBeVisible()
+  })
 
   test('Custom scheme shows user-defined cards', async ({ page }) => {
-    await page.goto('/host');
-    await page.getByLabel('Your Name').fill('Alice');
-    await page.getByTestId('scheme-tile-custom').click();
-    await page.getByLabel('Custom Values').fill('Easy, Medium, Hard');
-    await page.getByRole('button', { name: 'Start Game' }).click();
+    await page.goto('/host')
+    await page.getByLabel('Your Name').fill('Alice')
+    await page.getByTestId('scheme-tile-custom').click()
+    await page.getByLabel('Custom Values').fill('Easy, Medium, Hard')
+    await page.getByRole('button', { name: 'Start Game' }).click()
 
-    await expect(page).toHaveURL('/game');
-    await expect(page.getByText('Easy', { exact: true })).toBeVisible();
-    await expect(page.getByText('Medium', { exact: true })).toBeVisible();
-    await expect(page.getByText('Hard', { exact: true })).toBeVisible();
-  });
+    await expect(page).toHaveURL('/game')
+    await expect(page.getByText('Easy', { exact: true })).toBeVisible()
+    await expect(page.getByText('Medium', { exact: true })).toBeVisible()
+    await expect(page.getByText('Hard', { exact: true })).toBeVisible()
+  })
 
   test('enabling unsure toggle shows ? card', async ({ page }) => {
-    await page.goto('/host');
-    await page.getByLabel('Your Name').fill('Alice');
+    await page.goto('/host')
+    await page.getByLabel('Your Name').fill('Alice')
 
     // Enable Include ? (unsure) switch (defaults OFF)
-    const unsureSwitch = page.getByText('Include ? (unsure)').locator('..').locator('.MuiSwitch-input');
-    await unsureSwitch.click({ force: true });
+    const unsureSwitch = page
+      .getByText('Include ? (unsure)')
+      .locator('..')
+      .locator('.MuiSwitch-input')
+    await unsureSwitch.click({ force: true })
 
-    await page.getByRole('button', { name: 'Start Game' }).click();
+    await page.getByRole('button', { name: 'Start Game' }).click()
 
-    await expect(page).toHaveURL('/game');
-    await expect(page.getByText('5', { exact: true })).toBeVisible();
-    await expect(page.getByText('?', { exact: true })).toBeVisible();
-  });
-});
+    await expect(page).toHaveURL('/game')
+    await expect(page.getByText('5', { exact: true })).toBeVisible()
+    await expect(page.getByText('?', { exact: true })).toBeVisible()
+  })
+})
 
 test.describe('Copy Session ID', () => {
   test('copy button shows checkmark after click', async ({ page, context }) => {
-    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    await context.grantPermissions(['clipboard-read', 'clipboard-write'])
 
-    await page.goto('/host');
-    await page.getByLabel('Your Name').fill('Alice');
-    await page.getByRole('button', { name: 'Start Game' }).click();
-    await expect(page).toHaveURL('/game');
+    await page.goto('/host')
+    await page.getByLabel('Your Name').fill('Alice')
+    await page.getByRole('button', { name: 'Start Game' }).click()
+    await expect(page).toHaveURL('/game')
 
-    await page.locator('.MuiChip-deleteIcon').click();
-    await expect(page.locator('[data-testid="CheckIcon"]')).toBeVisible({ timeout: 2000 });
-  });
-});
+    await page.locator('.MuiChip-deleteIcon').click()
+    await expect(page.locator('[data-testid="CheckIcon"]')).toBeVisible({ timeout: 2000 })
+  })
+})

--- a/planningpoker-web/tests/session-labels-csv.spec.js
+++ b/planningpoker-web/tests/session-labels-csv.spec.js
@@ -108,7 +108,7 @@ test.describe('Session Labels', () => {
       await playerPage.getByText('8', { exact: true }).click()
 
       // Both should see results with label
-      await expect(hostPage.getByText('Results')).toBeVisible({ timeout: 15000 })
+      await expect(hostPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
       await expect(hostPage.getByText('Sprint 42')).toBeVisible()
       await expect(playerPage.getByText('Sprint 42')).toBeVisible({
         timeout: 15000,
@@ -141,7 +141,7 @@ test.describe('Session Labels', () => {
       await hostPage.getByText('3', { exact: true }).click()
       await playerPage.getByText('5', { exact: true }).click()
 
-      await expect(hostPage.getByText('Results')).toBeVisible({ timeout: 15000 })
+      await expect(hostPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
 
       // Host clicks Next Item
       await hostPage.getByRole('button', { name: 'Next Item' }).click()
@@ -266,7 +266,7 @@ test.describe('Consensus', () => {
       await hostPage.getByText('5', { exact: true }).click()
       await playerPage.getByText('5', { exact: true }).click()
 
-      await expect(hostPage.getByText('Results')).toBeVisible({ timeout: 15000 })
+      await expect(hostPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
 
       // Host sees the card-rail picker with "5" pre-selected (mode); non-host sees nothing
       await expect(hostPage.getByText('Lock in the estimate')).toBeVisible()
@@ -295,7 +295,7 @@ test.describe('Consensus', () => {
       await hostPage.getByText('5', { exact: true }).click()
       await playerPage.getByText('8', { exact: true }).click()
 
-      await expect(hostPage.getByText('Results')).toBeVisible({ timeout: 15000 })
+      await expect(hostPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
 
       // Mode picks '5' (alphabetical tiebreak); host clicks the '8' card to override
       const fiveCard = hostPage.getByRole('button', { name: /^Set consensus to 5/ })
@@ -330,7 +330,7 @@ test.describe('CSV Export', () => {
       await hostPage.getByText('5', { exact: true }).click()
       await playerPage.getByText('5', { exact: true }).click()
 
-      await expect(hostPage.getByText('Results')).toBeVisible({ timeout: 15000 })
+      await expect(hostPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
 
       // Export CSV button should be enabled even on first round
       const exportBtn = hostPage.getByRole('button', { name: 'Export CSV' })
@@ -365,7 +365,7 @@ test.describe('CSV Export', () => {
 
       await hostPage.getByText('5', { exact: true }).click()
       await playerPage.getByText('8', { exact: true }).click()
-      await expect(hostPage.getByText('Results')).toBeVisible({ timeout: 15000 })
+      await expect(hostPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
 
       await hostPage.getByRole('button', { name: 'Next Item' }).click()
       await expect(hostPage.getByText('Cast your estimate')).toBeVisible({
@@ -375,7 +375,7 @@ test.describe('CSV Export', () => {
       // Vote again to see export button
       await hostPage.getByText('3', { exact: true }).click()
       await playerPage.getByText('3', { exact: true }).click()
-      await expect(hostPage.getByText('Results')).toBeVisible({ timeout: 15000 })
+      await expect(hostPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
 
       // Intercept download (button is below the chart now — scroll it in)
       const exportBtn = hostPage.getByRole('button', { name: 'Export CSV' })
@@ -418,7 +418,7 @@ test.describe('CSV Export', () => {
       // Only Alice and Bob vote; Carol does not
       await hostPage.getByText('5', { exact: true }).click()
       await voterPage.getByText('5', { exact: true }).click()
-      await expect(hostPage.getByText('Results')).toBeVisible({ timeout: 15000 })
+      await expect(hostPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
 
       const exportBtn = hostPage.getByRole('button', { name: 'Export CSV' })
       await exportBtn.scrollIntoViewIfNeeded()
@@ -494,7 +494,7 @@ test.describe('Accessibility announcements', () => {
         timeout: 15000,
       })
 
-      await expect(hostPage.getByText('Results')).toBeVisible({ timeout: 15000 })
+      await expect(hostPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
     } finally {
       await hostCtx.close()
       await playerCtx.close()
@@ -598,7 +598,7 @@ test.describe('Accessibility announcements', () => {
       await hostPage.getByText('5', { exact: true }).click()
       await playerPage.getByText('5', { exact: true }).click()
 
-      await expect(hostPage.getByText('Results')).toBeVisible({ timeout: 15000 })
+      await expect(hostPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
       await expect(hostPage.getByRole('button', { name: /^Set consensus to 5/ })).toHaveAttribute(
         'aria-pressed',
         'true',


### PR DESCRIPTION
## Summary
- Replace the generic "Results" title with a `ROUND N · REVEALED` eyebrow; story label promoted to H2 below
- Footer caption upgraded to a bordered disclosure row that toggles an inline history list and aligns Export CSV on the right
- Non-admins now see session history + Export CSV (dropped the `isAdmin` gate on the footer block, per design decision)

Implements V5 from the "Results Panel Explorations" Claude Design handoff.

## Notes
- Unrelated semicolon diff in the three `tests/*.spec.js` files is automated prettier cleanup triggered by the pre-commit hook — style-only, no behaviour change.
- E2E tests switched from `getByText('Results')` to `getByText(/^Round \d+/)` since the word "Results" no longer appears in the panel.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` → 91/91 unit tests pass
- [x] `npm run build` clean
- [x] `./gradlew planningpoker-api:bootJar` clean
- [x] `npx playwright test` → 41/41 e2e tests pass against a live backend
- [ ] Eyeball on Railway preview after merge (dark + light theme)

🤖 Generated with [Claude Code](https://claude.com/claude-code)