### PR TITLE
feat(ui): show session history and CSV export on the voting screen

### DIFF
--- a/planningpoker-api/src/main/java/com/richashworth/planningpoker/controller/GameController.java
+++ b/planningpoker-api/src/main/java/com/richashworth/planningpoker/controller/GameController.java
@@ -7,12 +7,17 @@ import com.richashworth.planningpoker.model.CreateSessionRequest;
 import com.richashworth.planningpoker.model.Estimate;
 import com.richashworth.planningpoker.model.RefreshResponse;
 import com.richashworth.planningpoker.model.ResetResponse;
+import com.richashworth.planningpoker.model.Round;
 import com.richashworth.planningpoker.model.SchemeConfig;
 import com.richashworth.planningpoker.model.SessionResponse;
 import com.richashworth.planningpoker.service.SessionManager;
 import com.richashworth.planningpoker.util.LogSafeIds;
 import com.richashworth.planningpoker.util.MessagingUtils;
+import java.time.Instant;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -68,8 +73,17 @@ public class GameController {
     int round = sessionManager.getRound(sessionId);
     List<Estimate> results = sessionManager.getResults(sessionId);
     String label = sessionManager.getLabel(sessionId);
+    List<Round> completedRounds = sessionManager.getCompletedRounds(sessionId);
     return new SessionResponse(
-        host, null, config.schemeType(), values, config.includeUnsure(), round, results, label);
+        host,
+        null,
+        config.schemeType(),
+        values,
+        config.includeUnsure(),
+        round,
+        results,
+        label,
+        completedRounds);
   }
 
   /**
@@ -104,7 +118,8 @@ public class GameController {
         schemeConfig.includeUnsure(),
         round,
         List.of(),
-        "");
+        "",
+        List.of());
   }
 
   /**
@@ -143,9 +158,10 @@ public class GameController {
     String label = sessionManager.getLabel(sessionId);
     List<String> users = sessionManager.getSessionUsers(sessionId);
     String host = sessionManager.getHost(sessionId);
+    List<Round> completedRounds = sessionManager.getCompletedRounds(sessionId);
     messagingUtils.sendResultsMessage(sessionId);
     messagingUtils.sendUsersMessage(sessionId);
-    return new RefreshResponse(round, results, label, users, host);
+    return new RefreshResponse(round, results, label, users, host, completedRounds);
   }
 
   /** Returns the list of usernames currently registered in {@code sessionId}. */
@@ -225,26 +241,61 @@ public class GameController {
   }
 
   /**
-   * Clears the current round's estimates and increments the round counter. Broadcasts a {@code
-   * RESET_MESSAGE} with the new round number so all clients return to the voting view. Currently
-   * any session member can trigger a reset; host-only enforcement is not applied here.
+   * Snapshots the current round's estimates into the session's completed-rounds history (if any
+   * votes were cast), clears the current estimates, and increments the round counter. Broadcasts
+   * {@code ROUND_COMPLETED_MESSAGE} (when a snapshot was taken) followed by {@code RESET_MESSAGE}
+   * so every participant's client converges on the same history and returns to the voting view.
+   * Currently any session member can trigger a reset; host-only enforcement is not applied here.
+   *
+   * <p>The optional {@code consensus} parameter lets the host supply an override (e.g. from the
+   * consensus card rail); if omitted, the server falls back to the mode of the captured estimates.
    *
    * @throws IllegalArgumentException if the session is not active or the user is not a member.
    */
   @PostMapping("reset")
   public ResetResponse reset(
       @RequestParam(name = "sessionId") final String sessionId,
-      @RequestParam(name = "userName") final String userName) {
+      @RequestParam(name = "userName") final String userName,
+      @RequestParam(name = "consensus", required = false) final String consensus) {
     int newRound;
+    Round snapshot = null;
     synchronized (sessionManager) {
       validateSessionMembership(sessionId, userName);
       logger.info(
           "host {} reset session {}", LogSafeIds.hash(userName), LogSafeIds.hash(sessionId));
+      List<Estimate> votes = sessionManager.getResults(sessionId);
+      if (!votes.isEmpty()) {
+        String resolvedConsensus =
+            (consensus != null && !consensus.isBlank()) ? consensus : modeOf(votes);
+        snapshot =
+            new Round(
+                sessionManager.getRound(sessionId),
+                sessionManager.getLabel(sessionId),
+                resolvedConsensus,
+                votes,
+                Instant.now().toString());
+        sessionManager.appendCompletedRound(sessionId, snapshot);
+      }
       sessionManager.resetSession(sessionId);
       newRound = sessionManager.incrementAndGetRound(sessionId);
     }
+    if (snapshot != null) {
+      messagingUtils.sendRoundCompletedMessage(sessionId, snapshot);
+    }
     messagingUtils.sendResetMessage(sessionId, newRound);
     return new ResetResponse(newRound);
+  }
+
+  private static String modeOf(List<Estimate> votes) {
+    return votes.stream()
+        .collect(Collectors.groupingBy(Estimate::estimateValue, Collectors.counting()))
+        .entrySet()
+        .stream()
+        .max(
+            Comparator.<Map.Entry<String, Long>>comparingLong(Map.Entry::getValue)
+                .thenComparing(Map.Entry::getKey, Comparator.reverseOrder()))
+        .map(Map.Entry::getKey)
+        .orElse("");
   }
 
   /**

--- a/planningpoker-api/src/main/java/com/richashworth/planningpoker/model/RefreshResponse.java
+++ b/planningpoker-api/src/main/java/com/richashworth/planningpoker/model/RefreshResponse.java
@@ -3,4 +3,9 @@ package com.richashworth.planningpoker.model;
 import java.util.List;
 
 public record RefreshResponse(
-    int round, List<Estimate> results, String label, List<String> users, String host) {}
+    int round,
+    List<Estimate> results,
+    String label,
+    List<String> users,
+    String host,
+    List<Round> completedRounds) {}

--- a/planningpoker-api/src/main/java/com/richashworth/planningpoker/model/Round.java
+++ b/planningpoker-api/src/main/java/com/richashworth/planningpoker/model/Round.java
@@ -1,0 +1,6 @@
+package com.richashworth.planningpoker.model;
+
+import java.util.List;
+
+public record Round(
+    int round, String label, String consensus, List<Estimate> votes, String timestamp) {}

--- a/planningpoker-api/src/main/java/com/richashworth/planningpoker/model/SessionResponse.java
+++ b/planningpoker-api/src/main/java/com/richashworth/planningpoker/model/SessionResponse.java
@@ -10,4 +10,5 @@ public record SessionResponse(
     boolean includeUnsure,
     int round,
     List<Estimate> results,
-    String label) {}
+    String label,
+    List<Round> completedRounds) {}

--- a/planningpoker-api/src/main/java/com/richashworth/planningpoker/service/SessionManager.java
+++ b/planningpoker-api/src/main/java/com/richashworth/planningpoker/service/SessionManager.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimaps;
 import com.richashworth.planningpoker.model.Estimate;
+import com.richashworth.planningpoker.model.Round;
 import com.richashworth.planningpoker.model.SchemeConfig;
 import com.richashworth.planningpoker.model.SchemeType;
 import com.richashworth.planningpoker.util.LogSafeIds;
@@ -36,6 +37,8 @@ public class SessionManager {
   private final ConcurrentHashMap<String, String> sessionHosts = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<String, String> sessionLabels = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<String, AtomicInteger> sessionRounds = new ConcurrentHashMap<>();
+  private final ListMultimap<String, Round> sessionCompletedRounds =
+      Multimaps.synchronizedListMultimap(ArrayListMultimap.create());
 
   public boolean isSessionActive(final String sessionId) {
     return activeSessions.contains(sessionId);
@@ -78,6 +81,15 @@ public class SessionManager {
 
   public int incrementAndGetRound(String sessionId) {
     return sessionRounds.computeIfAbsent(sessionId, k -> new AtomicInteger(0)).incrementAndGet();
+  }
+
+  public void appendCompletedRound(String sessionId, Round round) {
+    sessionCompletedRounds.put(sessionId, round);
+    touchSession(sessionId);
+  }
+
+  public List<Round> getCompletedRounds(String sessionId) {
+    return List.copyOf(sessionCompletedRounds.get(sessionId));
   }
 
   public List<String> getSessionLegalValues(String sessionId) {
@@ -140,6 +152,7 @@ public class SessionManager {
     sessionHosts.clear();
     sessionLabels.clear();
     sessionRounds.clear();
+    sessionCompletedRounds.clear();
   }
 
   public void resetSession(final String sessionId) {
@@ -197,6 +210,7 @@ public class SessionManager {
       sessionHosts.remove(sessionId);
       sessionLabels.remove(sessionId);
       sessionRounds.remove(sessionId);
+      sessionCompletedRounds.removeAll(sessionId);
     }
     if (!toEvict.isEmpty()) {
       logger.info("Evicted {} idle session(s)", toEvict.size());

--- a/planningpoker-api/src/main/java/com/richashworth/planningpoker/util/MessagingUtils.java
+++ b/planningpoker-api/src/main/java/com/richashworth/planningpoker/util/MessagingUtils.java
@@ -1,5 +1,6 @@
 package com.richashworth.planningpoker.util;
 
+import com.richashworth.planningpoker.model.Round;
 import com.richashworth.planningpoker.service.SessionManager;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -55,6 +56,12 @@ public class MessagingUtils {
         getTopic(TOPIC_RESULTS, sessionId), new Message(MessageType.USER_LEFT_MESSAGE, payload));
   }
 
+  public void sendRoundCompletedMessage(String sessionId, Round round) {
+    template.convertAndSend(
+        getTopic(TOPIC_RESULTS, sessionId),
+        new Message(MessageType.ROUND_COMPLETED_MESSAGE, round));
+  }
+
   Message resultsMessage(Object payload) {
     return new Message(MessageType.RESULTS_MESSAGE, payload);
   }
@@ -67,7 +74,8 @@ public class MessagingUtils {
     USERS_MESSAGE,
     RESULTS_MESSAGE,
     RESET_MESSAGE,
-    USER_LEFT_MESSAGE
+    USER_LEFT_MESSAGE,
+    ROUND_COMPLETED_MESSAGE
   }
 
   private record Message(MessageType type, Object payload) {}

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/GameControllerTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/GameControllerTest.java
@@ -251,8 +251,7 @@ class GameControllerTest extends AbstractControllerTest {
     when(sessionManager.isSessionActive(SESSION_ID)).thenReturn(true);
     when(sessionManager.getSessionUsers(SESSION_ID)).thenReturn(Lists.newArrayList());
     assertThrows(
-        IllegalArgumentException.class,
-        () -> gameController.reset(SESSION_ID, USER_NAME, null));
+        IllegalArgumentException.class, () -> gameController.reset(SESSION_ID, USER_NAME, null));
   }
 
   @Test

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/GameControllerTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/GameControllerTest.java
@@ -11,6 +11,7 @@ import com.richashworth.planningpoker.model.CreateSessionRequest;
 import com.richashworth.planningpoker.model.Estimate;
 import com.richashworth.planningpoker.model.RefreshResponse;
 import com.richashworth.planningpoker.model.ResetResponse;
+import com.richashworth.planningpoker.model.Round;
 import com.richashworth.planningpoker.model.SchemeConfig;
 import com.richashworth.planningpoker.model.SchemeType;
 import com.richashworth.planningpoker.model.SessionResponse;
@@ -35,6 +36,11 @@ class GameControllerTest extends AbstractControllerTest {
     List<Estimate> existing = List.of(new Estimate("HostUser", "5"));
     when(sessionManager.getResults(SESSION_ID)).thenReturn(existing);
     when(sessionManager.getLabel(SESSION_ID)).thenReturn("Sprint 2");
+    List<Round> priorRounds =
+        List.of(
+            new Round(
+                3, "Story A", "5", List.of(new Estimate("HostUser", "5")), "2026-04-21T10:00:00Z"));
+    when(sessionManager.getCompletedRounds(SESSION_ID)).thenReturn(priorRounds);
     SessionResponse response = gameController.joinSession(SESSION_ID, USER_NAME);
     assertEquals("fibonacci", response.schemeType());
     assertTrue(response.values().contains("1"));
@@ -44,6 +50,7 @@ class GameControllerTest extends AbstractControllerTest {
     assertEquals(4, response.round());
     assertEquals(existing, response.results());
     assertEquals("Sprint 2", response.label());
+    assertEquals(priorRounds, response.completedRounds());
     inOrder.verify(sessionManager, times(1)).registerUser(USER_NAME, SESSION_ID);
     inOrder.verify(messagingUtils, times(1)).sendUsersMessage(SESSION_ID);
   }
@@ -81,6 +88,7 @@ class GameControllerTest extends AbstractControllerTest {
     assertEquals(0, response.round());
     assertTrue(response.results().isEmpty());
     assertEquals("", response.label());
+    assertTrue(response.completedRounds().isEmpty());
     inOrder.verify(sessionManager, times(1)).createSession(any(SchemeConfig.class));
     inOrder.verify(sessionManager, times(1)).registerUser(USER_NAME, SESSION_ID);
     inOrder.verify(messagingUtils, times(1)).sendUsersMessage(SESSION_ID);
@@ -112,12 +120,18 @@ class GameControllerTest extends AbstractControllerTest {
     when(sessionManager.getLabel(SESSION_ID)).thenReturn("Sprint");
     when(sessionManager.getSessionUsers(SESSION_ID)).thenReturn(List.of("Alice", "Bob"));
     when(sessionManager.getHost(SESSION_ID)).thenReturn("Alice");
+    List<Round> priorRounds =
+        List.of(
+            new Round(
+                1, "Story A", "3", List.of(new Estimate("Alice", "3")), "2026-04-21T10:00:00Z"));
+    when(sessionManager.getCompletedRounds(SESSION_ID)).thenReturn(priorRounds);
     RefreshResponse response = gameController.refresh(SESSION_ID);
     assertEquals(2, response.round());
     assertEquals(results, response.results());
     assertEquals("Sprint", response.label());
     assertEquals(List.of("Alice", "Bob"), response.users());
     assertEquals("Alice", response.host());
+    assertEquals(priorRounds, response.completedRounds());
     verify(messagingUtils).sendResultsMessage(SESSION_ID);
     verify(messagingUtils).sendUsersMessage(SESSION_ID);
   }
@@ -158,20 +172,87 @@ class GameControllerTest extends AbstractControllerTest {
   void testReset() {
     when(sessionManager.isSessionActive(SESSION_ID)).thenReturn(true);
     when(sessionManager.getSessionUsers(SESSION_ID)).thenReturn(Lists.newArrayList(USER_NAME));
+    when(sessionManager.getResults(SESSION_ID)).thenReturn(List.of());
     when(sessionManager.incrementAndGetRound(SESSION_ID)).thenReturn(4);
-    ResetResponse response = gameController.reset(SESSION_ID, USER_NAME);
+    ResetResponse response = gameController.reset(SESSION_ID, USER_NAME, null);
     assertEquals(4, response.round());
     verify(sessionManager).resetSession(SESSION_ID);
     verify(sessionManager).incrementAndGetRound(SESSION_ID);
     verify(messagingUtils).sendResetMessage(SESSION_ID, 4);
+    verify(messagingUtils, never()).sendRoundCompletedMessage(anyString(), any(Round.class));
     verify(messagingUtils, never()).sendResultsMessage(anyString());
+  }
+
+  @Test
+  void testResetWithVotesBroadcastsRoundCompleted() {
+    when(sessionManager.isSessionActive(SESSION_ID)).thenReturn(true);
+    when(sessionManager.getSessionUsers(SESSION_ID)).thenReturn(Lists.newArrayList(USER_NAME));
+    List<Estimate> votes =
+        List.of(new Estimate("Alice", "5"), new Estimate("Bob", "5"), new Estimate("Carol", "3"));
+    when(sessionManager.getResults(SESSION_ID)).thenReturn(votes);
+    when(sessionManager.getLabel(SESSION_ID)).thenReturn("Login page");
+    when(sessionManager.getRound(SESSION_ID)).thenReturn(2);
+    when(sessionManager.incrementAndGetRound(SESSION_ID)).thenReturn(3);
+
+    ResetResponse response = gameController.reset(SESSION_ID, USER_NAME, "8");
+
+    assertEquals(3, response.round());
+    org.mockito.ArgumentCaptor<Round> captor = org.mockito.ArgumentCaptor.forClass(Round.class);
+    verify(sessionManager).appendCompletedRound(eq(SESSION_ID), captor.capture());
+    Round stored = captor.getValue();
+    assertEquals(2, stored.round());
+    assertEquals("Login page", stored.label());
+    assertEquals("8", stored.consensus()); // explicit override preferred over mode
+    assertEquals(votes, stored.votes());
+    assertNotNull(stored.timestamp());
+    verify(messagingUtils).sendRoundCompletedMessage(SESSION_ID, stored);
+    verify(messagingUtils).sendResetMessage(SESSION_ID, 3);
+  }
+
+  @Test
+  void testResetWithoutConsensusFallsBackToMode() {
+    when(sessionManager.isSessionActive(SESSION_ID)).thenReturn(true);
+    when(sessionManager.getSessionUsers(SESSION_ID)).thenReturn(Lists.newArrayList(USER_NAME));
+    // Two "5"s and one "3" → mode is "5"
+    List<Estimate> votes =
+        List.of(new Estimate("Alice", "5"), new Estimate("Bob", "5"), new Estimate("Carol", "3"));
+    when(sessionManager.getResults(SESSION_ID)).thenReturn(votes);
+    when(sessionManager.getLabel(SESSION_ID)).thenReturn("");
+    when(sessionManager.getRound(SESSION_ID)).thenReturn(0);
+    when(sessionManager.incrementAndGetRound(SESSION_ID)).thenReturn(1);
+
+    gameController.reset(SESSION_ID, USER_NAME, null);
+
+    org.mockito.ArgumentCaptor<Round> captor = org.mockito.ArgumentCaptor.forClass(Round.class);
+    verify(sessionManager).appendCompletedRound(eq(SESSION_ID), captor.capture());
+    assertEquals("5", captor.getValue().consensus());
+  }
+
+  @Test
+  void testResetWithTiedVotesPicksAlphabeticallyFirstMode() {
+    when(sessionManager.isSessionActive(SESSION_ID)).thenReturn(true);
+    when(sessionManager.getSessionUsers(SESSION_ID)).thenReturn(Lists.newArrayList(USER_NAME));
+    // Tie: one "3" and one "5" → alphabetically first → "3"
+    List<Estimate> votes = List.of(new Estimate("Alice", "5"), new Estimate("Bob", "3"));
+    when(sessionManager.getResults(SESSION_ID)).thenReturn(votes);
+    when(sessionManager.getLabel(SESSION_ID)).thenReturn("");
+    when(sessionManager.getRound(SESSION_ID)).thenReturn(0);
+    when(sessionManager.incrementAndGetRound(SESSION_ID)).thenReturn(1);
+
+    gameController.reset(SESSION_ID, USER_NAME, "");
+
+    org.mockito.ArgumentCaptor<Round> captor = org.mockito.ArgumentCaptor.forClass(Round.class);
+    verify(sessionManager).appendCompletedRound(eq(SESSION_ID), captor.capture());
+    assertEquals("3", captor.getValue().consensus());
   }
 
   @Test
   void testResetNonMemberRejected() {
     when(sessionManager.isSessionActive(SESSION_ID)).thenReturn(true);
     when(sessionManager.getSessionUsers(SESSION_ID)).thenReturn(Lists.newArrayList());
-    assertThrows(IllegalArgumentException.class, () -> gameController.reset(SESSION_ID, USER_NAME));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> gameController.reset(SESSION_ID, USER_NAME, null));
   }
 
   @Test
@@ -312,8 +393,9 @@ class GameControllerTest extends AbstractControllerTest {
   void testResetClearsLabel() {
     when(sessionManager.isSessionActive(SESSION_ID)).thenReturn(true);
     when(sessionManager.getSessionUsers(SESSION_ID)).thenReturn(Lists.newArrayList(USER_NAME));
+    when(sessionManager.getResults(SESSION_ID)).thenReturn(List.of());
     when(sessionManager.incrementAndGetRound(SESSION_ID)).thenReturn(1);
-    gameController.reset(SESSION_ID, USER_NAME);
+    gameController.reset(SESSION_ID, USER_NAME, null);
     verify(sessionManager).resetSession(SESSION_ID);
     verify(messagingUtils).sendResetMessage(SESSION_ID, 1);
   }

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/service/SessionManagerTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/service/SessionManagerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.common.collect.Lists;
 import com.richashworth.planningpoker.model.Estimate;
+import com.richashworth.planningpoker.model.Round;
 import com.richashworth.planningpoker.model.SchemeConfig;
 import com.richashworth.planningpoker.model.SchemeType;
 import java.lang.reflect.Field;
@@ -107,6 +108,32 @@ class SessionManagerTest {
     sessionManager.resetSession(sessionId);
     assertTrue(sessionManager.getResults(sessionId).isEmpty());
     assertEquals(Lists.newArrayList(userName), sessionManager.getSessionUsers(sessionId));
+  }
+
+  @Test
+  void testAppendAndGetCompletedRounds() {
+    final String sessionId = sessionManager.createSession();
+    assertTrue(sessionManager.getCompletedRounds(sessionId).isEmpty());
+
+    Round r1 =
+        new Round(1, "A", "5", List.of(new Estimate("Alice", "5")), "2026-04-21T10:00:00Z");
+    Round r2 =
+        new Round(2, "B", "3", List.of(new Estimate("Alice", "3")), "2026-04-21T10:05:00Z");
+    sessionManager.appendCompletedRound(sessionId, r1);
+    sessionManager.appendCompletedRound(sessionId, r2);
+
+    List<Round> rounds = sessionManager.getCompletedRounds(sessionId);
+    assertEquals(List.of(r1, r2), rounds);
+    assertThrows(UnsupportedOperationException.class, () -> rounds.add(r1));
+  }
+
+  @Test
+  void testCompletedRoundsClearedOnClearSessions() {
+    final String sessionId = sessionManager.createSession();
+    sessionManager.appendCompletedRound(
+        sessionId, new Round(1, "A", "5", List.of(), "2026-04-21T10:00:00Z"));
+    sessionManager.clearSessions();
+    assertTrue(sessionManager.getCompletedRounds(sessionId).isEmpty());
   }
 
   @Test

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/service/SessionManagerTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/service/SessionManagerTest.java
@@ -115,10 +115,8 @@ class SessionManagerTest {
     final String sessionId = sessionManager.createSession();
     assertTrue(sessionManager.getCompletedRounds(sessionId).isEmpty());
 
-    Round r1 =
-        new Round(1, "A", "5", List.of(new Estimate("Alice", "5")), "2026-04-21T10:00:00Z");
-    Round r2 =
-        new Round(2, "B", "3", List.of(new Estimate("Alice", "3")), "2026-04-21T10:05:00Z");
+    Round r1 = new Round(1, "A", "5", List.of(new Estimate("Alice", "5")), "2026-04-21T10:00:00Z");
+    Round r2 = new Round(2, "B", "3", List.of(new Estimate("Alice", "3")), "2026-04-21T10:05:00Z");
     sessionManager.appendCompletedRound(sessionId, r1);
     sessionManager.appendCompletedRound(sessionId, r2);
 

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/util/MessagingUtilsTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/util/MessagingUtilsTest.java
@@ -5,6 +5,8 @@ import static com.richashworth.planningpoker.util.MessagingUtils.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
+import com.richashworth.planningpoker.model.Estimate;
+import com.richashworth.planningpoker.model.Round;
 import com.richashworth.planningpoker.service.SessionManager;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -126,5 +128,25 @@ class MessagingUtilsTest {
     verify(template, times(1))
         .convertAndSend(eq(getTopic(TOPIC_RESULTS, SESSION_ID)), (Object) any());
     verifyNoMoreInteractions(template);
+  }
+
+  @Test
+  void testSendRoundCompletedMessageEmitsOnce() {
+    Round round =
+        new Round(
+            3,
+            "Login page",
+            "5",
+            List.of(new Estimate("Alice", "5"), new Estimate("Bob", "5")),
+            "2026-04-21T10:00:00Z");
+    messagingUtils.sendRoundCompletedMessage(SESSION_ID, round);
+    ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+    verify(template, times(1))
+        .convertAndSend(eq(getTopic(TOPIC_RESULTS, SESSION_ID)), captor.capture());
+    verifyNoMoreInteractions(template);
+    String str = captor.getValue().toString();
+    org.junit.jupiter.api.Assertions.assertTrue(str.contains("ROUND_COMPLETED_MESSAGE"), str);
+    org.junit.jupiter.api.Assertions.assertTrue(str.contains("round=3"), str);
+    org.junit.jupiter.api.Assertions.assertTrue(str.contains("consensus=5"), str);
   }
 }

--- a/planningpoker-web/src/actions/__tests__/index.test.js
+++ b/planningpoker-web/src/actions/__tests__/index.test.js
@@ -18,6 +18,7 @@ import {
   RESULTS_REPLACE,
   LABEL_UPDATED,
   USERS_UPDATED,
+  ROUNDS_REPLACE,
 } from '../index'
 
 async function runThunkAsync(thunk) {
@@ -145,6 +146,26 @@ describe('resetSession', () => {
     expect(dispatched[0].type).toBe(RESET_SESSION)
     expect(dispatched[0].payload).toEqual({ round: 7 })
   })
+
+  it('omits the consensus param when none is supplied', async () => {
+    axios.post = vi.fn().mockResolvedValue({ data: { round: 1 } })
+
+    await runThunkAsync(resetSession('alice', 'abc12345'))
+
+    const [, params] = axios.post.mock.calls[0]
+    expect(params.get('userName')).toBe('alice')
+    expect(params.get('sessionId')).toBe('abc12345')
+    expect(params.has('consensus')).toBe(false)
+  })
+
+  it('includes the consensus param when supplied', async () => {
+    axios.post = vi.fn().mockResolvedValue({ data: { round: 2 } })
+
+    await runThunkAsync(resetSession('alice', 'abc12345', '8'))
+
+    const [, params] = axios.post.mock.calls[0]
+    expect(params.get('consensus')).toBe('8')
+  })
 })
 
 describe('refresh', () => {
@@ -152,7 +173,16 @@ describe('refresh', () => {
     vi.resetAllMocks()
   })
 
-  it('dispatches RESULTS_REPLACE, LABEL_UPDATED, and USERS_UPDATED from /refresh response', async () => {
+  it('dispatches RESULTS_REPLACE, LABEL_UPDATED, USERS_UPDATED, and ROUNDS_REPLACE from /refresh response', async () => {
+    const completedRounds = [
+      {
+        round: 1,
+        label: 'Story A',
+        consensus: '3',
+        votes: [{ userName: 'alice', estimateValue: '3' }],
+        timestamp: '2026-04-21T10:00:00Z',
+      },
+    ]
     axios.get = vi.fn().mockResolvedValue({
       data: {
         round: 5,
@@ -160,6 +190,7 @@ describe('refresh', () => {
         label: 'Sprint 1',
         users: ['alice', 'bob'],
         host: 'alice',
+        completedRounds,
       },
     })
 
@@ -177,5 +208,25 @@ describe('refresh', () => {
     const usersAction = dispatched.find((a) => a.type === USERS_UPDATED)
     expect(usersAction).toBeDefined()
     expect(usersAction.payload).toEqual({ users: ['alice', 'bob'], host: 'alice' })
+
+    const roundsAction = dispatched.find((a) => a.type === ROUNDS_REPLACE)
+    expect(roundsAction).toBeDefined()
+    expect(roundsAction.payload).toEqual(completedRounds)
+  })
+
+  it('skips ROUNDS_REPLACE when the refresh response omits completedRounds', async () => {
+    axios.get = vi.fn().mockResolvedValue({
+      data: {
+        round: 1,
+        results: [],
+        label: '',
+        users: ['alice'],
+        host: 'alice',
+      },
+    })
+
+    const dispatched = await runThunkAsync(refresh('abc12345', 'alice'))
+
+    expect(dispatched.find((a) => a.type === ROUNDS_REPLACE)).toBeUndefined()
   })
 })

--- a/planningpoker-web/src/actions/index.js
+++ b/planningpoker-web/src/actions/index.js
@@ -20,6 +20,7 @@ export const VOTE_OPTIMISTIC = 'vote-optimistic'
 export const SET_LABEL = 'set-label'
 export const LABEL_UPDATED = 'label-updated'
 export const ROUND_COMPLETED = 'round-completed'
+export const ROUNDS_REPLACE = 'rounds-replace'
 export const SET_CONSENSUS_OVERRIDE = 'set-consensus-override'
 
 export const showError = (message) => ({ type: 'show-error', payload: message })
@@ -55,6 +56,8 @@ export const userLeftReceived = (leaver) => ({
 export const labelUpdated = (label) => ({ type: LABEL_UPDATED, payload: label })
 
 export const roundCompleted = (round) => ({ type: ROUND_COMPLETED, payload: round })
+
+export const roundsReplace = (rounds) => ({ type: ROUNDS_REPLACE, payload: rounds })
 
 export const setConsensusOverride = (value) => ({ type: SET_CONSENSUS_OVERRIDE, payload: value })
 
@@ -140,13 +143,12 @@ export function vote(playerName, sessionId, estimateValue) {
   }
 }
 
-export function resetSession(playerName, sessionId) {
+export function resetSession(playerName, sessionId, consensus) {
   return async (dispatch) => {
     try {
-      const { data } = await axios.post(
-        `${API_ROOT_URL}/reset`,
-        new URLSearchParams({ sessionId, userName: playerName }),
-      )
+      const params = { sessionId, userName: playerName }
+      if (consensus != null && consensus !== '') params.consensus = consensus
+      const { data } = await axios.post(`${API_ROOT_URL}/reset`, new URLSearchParams(params))
       dispatch({ type: RESET_SESSION, payload: data })
     } catch (err) {
       dispatch({ type: RESET_SESSION, payload: err, error: true })
@@ -194,6 +196,7 @@ export function refresh(sessionId, playerName) {
       dispatch(resultsReplace(data.round, data.results, playerName))
       dispatch(labelUpdated(data.label || ''))
       if (Array.isArray(data.users)) dispatch(usersUpdated({ users: data.users, host: data.host }))
+      if (Array.isArray(data.completedRounds)) dispatch(roundsReplace(data.completedRounds))
     } catch (err) {
       console.error('Failed to refresh session state', err)
     }

--- a/planningpoker-web/src/containers/GamePane.jsx
+++ b/planningpoker-web/src/containers/GamePane.jsx
@@ -4,6 +4,7 @@ import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import Vote from './Vote'
 import Results from './Results'
+import SessionHistory from './SessionHistory'
 import LiveAnnouncer from '../components/LiveAnnouncer'
 import { calcConsensus } from '../utils/consensus'
 
@@ -95,6 +96,7 @@ export default function GamePane({ connected }) {
         ) : (
           <Vote />
         )}
+        <SessionHistory consensusOverride={consensusOverride} />
       </Box>
     </>
   )

--- a/planningpoker-web/src/containers/Results.jsx
+++ b/planningpoker-web/src/containers/Results.jsx
@@ -1,20 +1,12 @@
-import { useState } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import Button from '@mui/material/Button'
-import DownloadIcon from '@mui/icons-material/Download'
-import ChevronRightIcon from '@mui/icons-material/ChevronRight'
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import ResultsTable from './ResultsTable'
 import ResultsChart from './ResultsChart'
 import ConsensusCardRail from '../components/ConsensusCardRail'
 import { resetSession, roundCompleted } from '../actions'
 import { calcConsensus } from '../utils/consensus'
-import { generateCsv, downloadCsv } from '../utils/csvExport'
-
-const fmtTime = (iso) =>
-  new Date(iso).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
 
 export default function Results({ consensusOverride, setConsensusOverride }) {
   const dispatch = useDispatch()
@@ -24,14 +16,11 @@ export default function Results({ consensusOverride, setConsensusOverride }) {
   const currentLabel = useSelector((state) => state.game.currentLabel)
   const results = useSelector((state) => state.results)
   const rounds = useSelector((state) => state.rounds)
-  const users = useSelector((state) => state.users)
   const legalEstimates = useSelector((state) => state.game.legalEstimates)
-  const [historyOpen, setHistoryOpen] = useState(false)
 
   const autoConsensus = calcConsensus(results)
   const displayConsensus = consensusOverride || autoConsensus
   const totalRounds = rounds.length + (results.length > 0 ? 1 : 0)
-  const hasAnyHistory = rounds.length > 0 || results.length > 0
 
   const handleNextItem = () => {
     const round = {
@@ -43,21 +32,6 @@ export default function Results({ consensusOverride, setConsensusOverride }) {
     dispatch(roundCompleted(round))
     setConsensusOverride(null)
     dispatch(resetSession(playerName, sessionId))
-  }
-
-  const handleExportCsv = () => {
-    const currentRound = {
-      label: currentLabel,
-      consensus: consensusOverride || calcConsensus(results),
-      votes: [...results],
-      timestamp: new Date().toISOString(),
-    }
-    const allRounds = [...rounds, currentRound]
-    // Include all current session users plus any historical voters (who may have since left)
-    const historicalVoters = allRounds.flatMap((r) => r.votes.map((v) => v.userName))
-    const allPlayers = [...new Set([...users, ...historicalVoters])].sort()
-    const csv = generateCsv(allRounds, allPlayers)
-    downloadCsv(csv, `planning-poker-${sessionId}.csv`)
   }
 
   return (
@@ -165,138 +139,6 @@ export default function Results({ consensusOverride, setConsensusOverride }) {
         </Box>
         <ResultsTable />
       </Box>
-      {hasAnyHistory && (
-        <Box sx={{ mt: 2.5 }}>
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-              gap: 2,
-              flexWrap: 'wrap',
-              px: 1.75,
-              py: 1.25,
-              border: '1px solid',
-              borderColor: 'divider',
-              borderRadius: 1,
-              bgcolor: 'background.paper',
-            }}
-          >
-            {rounds.length > 0 ? (
-              <Button
-                variant="text"
-                onClick={() => setHistoryOpen((v) => !v)}
-                aria-expanded={historyOpen}
-                startIcon={historyOpen ? <ExpandMoreIcon /> : <ChevronRightIcon />}
-                sx={{
-                  color: 'text.primary',
-                  fontSize: '0.8125rem',
-                  fontWeight: 600,
-                  p: 0,
-                  minWidth: 0,
-                  '&:hover': { bgcolor: 'transparent' },
-                  '& .MuiButton-startIcon': { mr: 0.75 },
-                }}
-              >
-                {historyOpen ? 'Hide' : 'Show'} session history
-                <Box component="span" sx={{ color: 'text.disabled', fontWeight: 500, ml: 0.75 }}>
-                  · {rounds.length} completed {rounds.length === 1 ? 'round' : 'rounds'}
-                </Box>
-              </Button>
-            ) : (
-              <Typography
-                variant="caption"
-                color="text.secondary"
-                sx={{
-                  letterSpacing: '0.08em',
-                  textTransform: 'uppercase',
-                  fontSize: '0.7rem',
-                }}
-              >
-                Session history · {totalRounds} {totalRounds === 1 ? 'round' : 'rounds'}
-              </Typography>
-            )}
-            <Button
-              variant="outlined"
-              size="small"
-              startIcon={<DownloadIcon />}
-              onClick={handleExportCsv}
-            >
-              Export CSV
-            </Button>
-          </Box>
-          {historyOpen && rounds.length > 0 && (
-            <Box
-              sx={{
-                mt: 1,
-                border: '1px solid',
-                borderColor: 'divider',
-                borderRadius: 1,
-                bgcolor: 'background.paper',
-                overflow: 'hidden',
-              }}
-            >
-              {rounds.map((r, i) => (
-                <Box
-                  key={i}
-                  sx={{
-                    display: 'grid',
-                    gridTemplateColumns: 'auto 1fr auto auto',
-                    alignItems: 'center',
-                    gap: 1.5,
-                    px: 1.75,
-                    py: 1.25,
-                    borderTop: i === 0 ? 'none' : '1px solid',
-                    borderColor: 'divider',
-                  }}
-                >
-                  <Typography
-                    sx={{
-                      color: 'text.disabled',
-                      fontSize: '0.6875rem',
-                      fontWeight: 700,
-                      fontVariantNumeric: 'tabular-nums',
-                      minWidth: 24,
-                    }}
-                  >
-                    #{i + 1}
-                  </Typography>
-                  <Typography
-                    sx={{
-                      color: 'text.primary',
-                      fontSize: '0.8125rem',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
-                    }}
-                  >
-                    {r.label || <em>No label</em>}
-                  </Typography>
-                  <Typography sx={{ color: 'text.disabled', fontSize: '0.6875rem' }}>
-                    {fmtTime(r.timestamp)}
-                  </Typography>
-                  <Box
-                    sx={{
-                      px: 1,
-                      py: 0.25,
-                      borderRadius: 0.75,
-                      bgcolor: 'action.hover',
-                      color: 'text.primary',
-                      fontSize: '0.8125rem',
-                      fontWeight: 700,
-                      fontVariantNumeric: 'tabular-nums',
-                      textAlign: 'center',
-                      minWidth: 28,
-                    }}
-                  >
-                    {r.consensus}
-                  </Box>
-                </Box>
-              ))}
-            </Box>
-          )}
-        </Box>
-      )}
     </Box>
   )
 }

--- a/planningpoker-web/src/containers/Results.jsx
+++ b/planningpoker-web/src/containers/Results.jsx
@@ -5,7 +5,7 @@ import Button from '@mui/material/Button'
 import ResultsTable from './ResultsTable'
 import ResultsChart from './ResultsChart'
 import ConsensusCardRail from '../components/ConsensusCardRail'
-import { resetSession, roundCompleted } from '../actions'
+import { resetSession } from '../actions'
 import { calcConsensus } from '../utils/consensus'
 
 export default function Results({ consensusOverride, setConsensusOverride }) {
@@ -23,15 +23,9 @@ export default function Results({ consensusOverride, setConsensusOverride }) {
   const totalRounds = rounds.length + (results.length > 0 ? 1 : 0)
 
   const handleNextItem = () => {
-    const round = {
-      label: currentLabel,
-      consensus: consensusOverride || calcConsensus(results),
-      votes: [...results],
-      timestamp: new Date().toISOString(),
-    }
-    dispatch(roundCompleted(round))
+    const consensus = consensusOverride || calcConsensus(results) || ''
     setConsensusOverride(null)
-    dispatch(resetSession(playerName, sessionId))
+    dispatch(resetSession(playerName, sessionId, consensus))
   }
 
   return (

--- a/planningpoker-web/src/containers/SessionHistory.jsx
+++ b/planningpoker-web/src/containers/SessionHistory.jsx
@@ -1,0 +1,179 @@
+import { useState } from 'react'
+import { useSelector } from 'react-redux'
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+import Button from '@mui/material/Button'
+import DownloadIcon from '@mui/icons-material/Download'
+import ChevronRightIcon from '@mui/icons-material/ChevronRight'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import { calcConsensus } from '../utils/consensus'
+import { generateCsv, downloadCsv } from '../utils/csvExport'
+
+const fmtTime = (iso) =>
+  new Date(iso).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
+
+export default function SessionHistory({ consensusOverride = null }) {
+  const sessionId = useSelector((state) => state.game.sessionId)
+  const currentLabel = useSelector((state) => state.game.currentLabel)
+  const rounds = useSelector((state) => state.rounds)
+  const users = useSelector((state) => state.users)
+  const results = useSelector((state) => state.results)
+  const voted = useSelector((state) => state.voted)
+  const [historyOpen, setHistoryOpen] = useState(false)
+
+  const hasInflightRound = voted && results.length > 0
+  const hasAnyHistory = rounds.length > 0 || hasInflightRound
+  const totalRounds = rounds.length + (hasInflightRound ? 1 : 0)
+
+  if (!hasAnyHistory) return null
+
+  const handleExportCsv = () => {
+    const allRounds = [...rounds]
+    if (hasInflightRound) {
+      allRounds.push({
+        label: currentLabel,
+        consensus: consensusOverride || calcConsensus(results),
+        votes: [...results],
+        timestamp: new Date().toISOString(),
+      })
+    }
+    // Include all current session users plus any historical voters (who may have since left)
+    const historicalVoters = allRounds.flatMap((r) => r.votes.map((v) => v.userName))
+    const allPlayers = [...new Set([...users, ...historicalVoters])].sort()
+    const csv = generateCsv(allRounds, allPlayers)
+    downloadCsv(csv, `planning-poker-${sessionId}.csv`)
+  }
+
+  return (
+    <Box sx={{ mt: 2.5 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 2,
+          flexWrap: 'wrap',
+          px: 1.75,
+          py: 1.25,
+          border: '1px solid',
+          borderColor: 'divider',
+          borderRadius: 1,
+          bgcolor: 'background.paper',
+        }}
+      >
+        {rounds.length > 0 ? (
+          <Button
+            variant="text"
+            onClick={() => setHistoryOpen((v) => !v)}
+            aria-expanded={historyOpen}
+            startIcon={historyOpen ? <ExpandMoreIcon /> : <ChevronRightIcon />}
+            sx={{
+              color: 'text.primary',
+              fontSize: '0.8125rem',
+              fontWeight: 600,
+              p: 0,
+              minWidth: 0,
+              '&:hover': { bgcolor: 'transparent' },
+              '& .MuiButton-startIcon': { mr: 0.75 },
+            }}
+          >
+            {historyOpen ? 'Hide' : 'Show'} session history
+            <Box component="span" sx={{ color: 'text.disabled', fontWeight: 500, ml: 0.75 }}>
+              · {rounds.length} completed {rounds.length === 1 ? 'round' : 'rounds'}
+            </Box>
+          </Button>
+        ) : (
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              fontSize: '0.7rem',
+            }}
+          >
+            Session history · {totalRounds} {totalRounds === 1 ? 'round' : 'rounds'}
+          </Typography>
+        )}
+        <Button
+          variant="outlined"
+          size="small"
+          startIcon={<DownloadIcon />}
+          onClick={handleExportCsv}
+        >
+          Export CSV
+        </Button>
+      </Box>
+      {historyOpen && rounds.length > 0 && (
+        <Box
+          sx={{
+            mt: 1,
+            border: '1px solid',
+            borderColor: 'divider',
+            borderRadius: 1,
+            bgcolor: 'background.paper',
+            overflow: 'hidden',
+          }}
+        >
+          {rounds.map((r, i) => (
+            <Box
+              key={i}
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: 'auto 1fr auto auto',
+                alignItems: 'center',
+                gap: 1.5,
+                px: 1.75,
+                py: 1.25,
+                borderTop: i === 0 ? 'none' : '1px solid',
+                borderColor: 'divider',
+              }}
+            >
+              <Typography
+                sx={{
+                  color: 'text.disabled',
+                  fontSize: '0.6875rem',
+                  fontWeight: 700,
+                  fontVariantNumeric: 'tabular-nums',
+                  minWidth: 24,
+                }}
+              >
+                #{i + 1}
+              </Typography>
+              <Typography
+                sx={{
+                  color: 'text.primary',
+                  fontSize: '0.8125rem',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {r.label || <em>No label</em>}
+              </Typography>
+              <Typography sx={{ color: 'text.disabled', fontSize: '0.6875rem' }}>
+                {fmtTime(r.timestamp)}
+              </Typography>
+              <Box
+                sx={{
+                  px: 1,
+                  py: 0.25,
+                  borderRadius: 0.75,
+                  bgcolor: 'action.hover',
+                  color: 'text.primary',
+                  fontSize: '0.8125rem',
+                  fontWeight: 700,
+                  fontVariantNumeric: 'tabular-nums',
+                  textAlign: 'center',
+                  minWidth: 28,
+                }}
+              >
+                {r.consensus}
+              </Box>
+            </Box>
+          ))}
+        </Box>
+      )}
+    </Box>
+  )
+}

--- a/planningpoker-web/src/containers/__tests__/Results.test.jsx
+++ b/planningpoker-web/src/containers/__tests__/Results.test.jsx
@@ -10,11 +10,6 @@ vi.mock('axios', () => ({
   },
 }))
 
-vi.mock('../../utils/csvExport', () => ({
-  generateCsv: vi.fn(() => 'csv-content'),
-  downloadCsv: vi.fn(),
-}))
-
 vi.mock('react-chartjs-2', () => ({
   Bar: () => null,
 }))
@@ -22,7 +17,6 @@ vi.mock('react-chartjs-2', () => ({
 import axios from 'axios'
 import Results from '../Results'
 import { renderWithStore } from '../../testUtils/renderWithStore'
-import { generateCsv, downloadCsv } from '../../utils/csvExport'
 
 function baseState(overrides = {}) {
   return {
@@ -75,13 +69,12 @@ describe('Results container', () => {
     expect(screen.getByText('Login screen')).toBeInTheDocument()
   })
 
-  it('shows "Next Item" and Export CSV buttons to the host', () => {
+  it('shows "Next Item" button to the host', () => {
     renderWithStore(
       <Results consensusOverride={null} setConsensusOverride={setConsensusOverride} />,
       { preloadedState: baseState() },
     )
     expect(screen.getByRole('button', { name: /Next Item/ })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /Export CSV/ })).toBeInTheDocument()
   })
 
   it('hides the host-only controls for non-host players', () => {
@@ -90,20 +83,6 @@ describe('Results container', () => {
       { preloadedState: baseState({ game: { isAdmin: false } }) },
     )
     expect(screen.queryByRole('button', { name: /Next Item/ })).not.toBeInTheDocument()
-  })
-
-  it('triggers CSV export through generateCsv + downloadCsv', async () => {
-    renderWithStore(
-      <Results consensusOverride={null} setConsensusOverride={setConsensusOverride} />,
-      { preloadedState: baseState() },
-    )
-
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /Export CSV/ }))
-    })
-
-    expect(generateCsv).toHaveBeenCalled()
-    expect(downloadCsv).toHaveBeenCalledWith('csv-content', 'planning-poker-abc12345.csv')
   })
 
   it('POSTs to /reset when "Next Item" is clicked', async () => {
@@ -117,16 +96,5 @@ describe('Results container', () => {
     })
 
     expect(axios.post).toHaveBeenCalledWith(expect.stringMatching(/\/reset$/), expect.anything())
-  })
-
-  it('shows "Show session history" only after at least one completed round', () => {
-    const withHistory = baseState({
-      rounds: [{ label: 'Prev', consensus: '3', votes: [], timestamp: new Date().toISOString() }],
-    })
-    renderWithStore(
-      <Results consensusOverride={null} setConsensusOverride={setConsensusOverride} />,
-      { preloadedState: withHistory },
-    )
-    expect(screen.getByRole('button', { name: /Show session history/ })).toBeInTheDocument()
   })
 })

--- a/planningpoker-web/src/containers/__tests__/SessionHistory.test.jsx
+++ b/planningpoker-web/src/containers/__tests__/SessionHistory.test.jsx
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen, fireEvent, act, cleanup } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+vi.mock('../../utils/csvExport', () => ({
+  generateCsv: vi.fn(() => 'csv-content'),
+  downloadCsv: vi.fn(),
+}))
+
+import SessionHistory from '../SessionHistory'
+import { renderWithStore } from '../../testUtils/renderWithStore'
+import { generateCsv, downloadCsv } from '../../utils/csvExport'
+
+function baseState(overrides = {}) {
+  return {
+    game: {
+      sessionId: 'abc12345',
+      playerName: 'alice',
+      isAdmin: false,
+      currentLabel: '',
+      legalEstimates: ['1', '2', '3', '5', '8'],
+      ...overrides.game,
+    },
+    results: overrides.results ?? [],
+    users: overrides.users ?? ['alice', 'bob'],
+    voted: overrides.voted ?? false,
+    notification: overrides.notification ?? { error: null },
+    rounds: overrides.rounds ?? [],
+  }
+}
+
+const completedRound = {
+  label: 'Story 1',
+  consensus: '5',
+  votes: [
+    { userName: 'alice', estimateValue: '5' },
+    { userName: 'bob', estimateValue: '5' },
+  ],
+  timestamp: '2026-04-21T10:00:00.000Z',
+}
+
+describe('SessionHistory container', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders nothing on a fresh session before the first reveal', () => {
+    const { container } = renderWithStore(<SessionHistory />, { preloadedState: baseState() })
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders on the voting screen after at least one completed round', () => {
+    renderWithStore(<SessionHistory />, {
+      preloadedState: baseState({ rounds: [completedRound] }),
+    })
+    expect(screen.getByRole('button', { name: /Show session history/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Export CSV/ })).toBeInTheDocument()
+  })
+
+  it('renders on the results screen while votes are revealed (no prior rounds)', () => {
+    renderWithStore(<SessionHistory />, {
+      preloadedState: baseState({
+        voted: true,
+        results: [{ userName: 'alice', estimateValue: '3' }],
+      }),
+    })
+    // No completed rounds yet → non-collapsible caption, but export is still available
+    expect(screen.getByText(/Session history · 1 round/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Export CSV/ })).toBeInTheDocument()
+  })
+
+  it('is visible to non-host players with history', () => {
+    renderWithStore(<SessionHistory />, {
+      preloadedState: baseState({
+        game: { isAdmin: false },
+        rounds: [completedRound],
+      }),
+    })
+    expect(screen.getByRole('button', { name: /Export CSV/ })).toBeInTheDocument()
+  })
+
+  it('exports only completed rounds when called from the voting screen', async () => {
+    renderWithStore(<SessionHistory />, {
+      preloadedState: baseState({ rounds: [completedRound] }),
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Export CSV/ }))
+    })
+
+    expect(generateCsv).toHaveBeenCalledTimes(1)
+    const [roundsArg, playersArg] = generateCsv.mock.calls[0]
+    expect(roundsArg).toEqual([completedRound])
+    expect(playersArg).toEqual(['alice', 'bob'])
+    expect(downloadCsv).toHaveBeenCalledWith('csv-content', 'planning-poker-abc12345.csv')
+  })
+
+  it('exports completed rounds plus the in-flight round when called from the results screen', async () => {
+    renderWithStore(<SessionHistory consensusOverride={null} />, {
+      preloadedState: baseState({
+        voted: true,
+        rounds: [completedRound],
+        results: [
+          { userName: 'alice', estimateValue: '8' },
+          { userName: 'bob', estimateValue: '8' },
+        ],
+        game: { currentLabel: 'Story 2' },
+      }),
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Export CSV/ }))
+    })
+
+    const [roundsArg] = generateCsv.mock.calls[0]
+    expect(roundsArg).toHaveLength(2)
+    expect(roundsArg[0]).toEqual(completedRound)
+    expect(roundsArg[1]).toMatchObject({
+      label: 'Story 2',
+      consensus: '8',
+      votes: [
+        { userName: 'alice', estimateValue: '8' },
+        { userName: 'bob', estimateValue: '8' },
+      ],
+    })
+  })
+
+  it('honours consensusOverride when building the in-flight round', async () => {
+    renderWithStore(<SessionHistory consensusOverride="13" />, {
+      preloadedState: baseState({
+        voted: true,
+        results: [
+          { userName: 'alice', estimateValue: '5' },
+          { userName: 'bob', estimateValue: '8' },
+        ],
+      }),
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Export CSV/ }))
+    })
+
+    const [roundsArg] = generateCsv.mock.calls[0]
+    expect(roundsArg[0].consensus).toBe('13')
+  })
+
+  it('includes historical voters who have since left the session', async () => {
+    const roundWithLeaver = {
+      ...completedRound,
+      votes: [
+        { userName: 'alice', estimateValue: '5' },
+        { userName: 'carol', estimateValue: '3' },
+      ],
+    }
+    renderWithStore(<SessionHistory />, {
+      preloadedState: baseState({
+        rounds: [roundWithLeaver],
+        users: ['alice', 'bob'],
+      }),
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Export CSV/ }))
+    })
+
+    const [, playersArg] = generateCsv.mock.calls[0]
+    expect(playersArg).toEqual(['alice', 'bob', 'carol'])
+  })
+})

--- a/planningpoker-web/src/pages/PlayGame.jsx
+++ b/planningpoker-web/src/pages/PlayGame.jsx
@@ -7,6 +7,7 @@ import useStomp from '../hooks/useStomp'
 import {
   resultsReplace,
   resultsUnion,
+  roundCompleted,
   userLeftReceived,
   usersUpdated,
   kicked,
@@ -90,6 +91,9 @@ export default function PlayGame() {
         }
         case 'USERS_MESSAGE':
           return dispatch(usersUpdated(msg.payload))
+        case 'ROUND_COMPLETED_MESSAGE':
+          if (msg.payload) dispatch(roundCompleted(msg.payload))
+          return
         default:
           return
       }

--- a/planningpoker-web/src/reducers/__tests__/reducer_rounds.test.js
+++ b/planningpoker-web/src/reducers/__tests__/reducer_rounds.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import reducer from '../reducer_rounds'
+import { CREATE_GAME, JOIN_GAME, LEAVE_GAME, ROUND_COMPLETED, ROUNDS_REPLACE } from '../../actions'
+
+const round = (overrides = {}) => ({
+  round: 1,
+  label: 'Story A',
+  consensus: '5',
+  votes: [{ userName: 'alice', estimateValue: '5' }],
+  timestamp: '2026-04-21T10:00:00.000Z',
+  ...overrides,
+})
+
+describe('rounds reducer', () => {
+  it('returns [] as initial state', () => {
+    expect(reducer(undefined, { type: '@@INIT' })).toEqual([])
+  })
+
+  it('appends a completed round', () => {
+    const r = round()
+    expect(reducer([], { type: ROUND_COMPLETED, payload: r })).toEqual([r])
+  })
+
+  it('dedupes ROUND_COMPLETED by (round, timestamp)', () => {
+    const r = round()
+    const state = [r]
+    const next = reducer(state, { type: ROUND_COMPLETED, payload: r })
+    expect(next).toBe(state)
+  })
+
+  it('allows two distinct rounds with different round numbers to coexist', () => {
+    const r1 = round({ round: 1 })
+    const r2 = round({ round: 2, timestamp: '2026-04-21T10:05:00.000Z' })
+    const after1 = reducer([], { type: ROUND_COMPLETED, payload: r1 })
+    const after2 = reducer(after1, { type: ROUND_COMPLETED, payload: r2 })
+    expect(after2).toEqual([r1, r2])
+  })
+
+  it('replaces the whole list on ROUNDS_REPLACE', () => {
+    const before = [round({ round: 1 })]
+    const incoming = [round({ round: 5 }), round({ round: 6, timestamp: '2026-04-21T11:00:00Z' })]
+    expect(reducer(before, { type: ROUNDS_REPLACE, payload: incoming })).toEqual(incoming)
+  })
+
+  it('hydrates from CREATE_GAME payload.completedRounds', () => {
+    const completedRounds = [round({ round: 2 })]
+    const action = { type: CREATE_GAME, payload: { completedRounds } }
+    expect(reducer([], action)).toEqual(completedRounds)
+  })
+
+  it('hydrates from JOIN_GAME payload.completedRounds', () => {
+    const completedRounds = [round({ round: 1 }), round({ round: 2, timestamp: 't2' })]
+    const action = { type: JOIN_GAME, payload: { completedRounds } }
+    expect(reducer([], action)).toEqual(completedRounds)
+  })
+
+  it('ignores JOIN_GAME when action.error is set', () => {
+    const state = [round()]
+    const action = { type: JOIN_GAME, payload: {}, error: true }
+    expect(reducer(state, action)).toBe(state)
+  })
+
+  it('resets on LEAVE_GAME', () => {
+    const state = [round()]
+    expect(reducer(state, { type: LEAVE_GAME })).toEqual([])
+  })
+})

--- a/planningpoker-web/src/reducers/reducer_rounds.js
+++ b/planningpoker-web/src/reducers/reducer_rounds.js
@@ -1,11 +1,25 @@
-import { ROUND_COMPLETED, LEAVE_GAME } from '../actions'
+import { CREATE_GAME, JOIN_GAME, ROUND_COMPLETED, ROUNDS_REPLACE, LEAVE_GAME } from '../actions'
 
 const initialState = []
 
 export default function (state = initialState, action) {
   switch (action.type) {
-    case ROUND_COMPLETED:
-      return [...state, action.payload]
+    case CREATE_GAME:
+    case JOIN_GAME:
+      if (action.error) return state
+      return Array.isArray(action.payload?.completedRounds) ? action.payload.completedRounds : []
+    case ROUND_COMPLETED: {
+      const incoming = action.payload
+      if (!incoming) return state
+      // Server is the source of truth; dedupe by (round, timestamp) so a repeat broadcast
+      // or a roundsReplace-then-ROUND_COMPLETED race can't double-insert.
+      const exists = state.some(
+        (r) => r.round === incoming.round && r.timestamp === incoming.timestamp,
+      )
+      return exists ? state : [...state, incoming]
+    }
+    case ROUNDS_REPLACE:
+      return Array.isArray(action.payload) ? action.payload : state
     case LEAVE_GAME:
       return initialState
     default:

--- a/planningpoker-web/tests/session-labels-csv.spec.js
+++ b/planningpoker-web/tests/session-labels-csv.spec.js
@@ -399,6 +399,78 @@ test.describe('CSV Export', () => {
     }
   })
 
+  test('export button is not rendered on a fresh session before the first reveal', async ({
+    browser,
+  }) => {
+    const hostCtx = await browser.newContext()
+    try {
+      const hostPage = await hostCtx.newPage()
+      await hostGame(hostPage, 'Alice')
+
+      // On round 1 before voting/reveal, there is no history and nothing to export
+      await expect(hostPage.getByText('Cast your estimate')).toBeVisible()
+      await expect(hostPage.getByRole('button', { name: 'Export CSV' })).toHaveCount(0)
+    } finally {
+      await hostCtx.close()
+    }
+  })
+
+  test('Export CSV is available on the voting screen of round 2', async ({ browser }) => {
+    const hostCtx = await browser.newContext()
+    const playerCtx = await browser.newContext()
+    try {
+      const hostPage = await hostCtx.newPage()
+      const sessionId = await hostGame(hostPage, 'Alice')
+
+      const playerPage = await playerCtx.newPage()
+      await joinGame(playerPage, 'Bob', sessionId)
+
+      await waitForWsReady(playerPage, sessionId, 'Alice')
+
+      // Set a label so the exported round has something identifiable
+      const labelInput = hostPage.getByPlaceholder('Item label (optional)')
+      await labelInput.fill('Story 1')
+      await labelInput.press('Enter')
+      await expect(playerPage.getByText('Story 1')).toBeVisible({ timeout: 15000 })
+
+      // Round 1: both vote, reveal, and advance
+      await hostPage.getByText('5', { exact: true }).click()
+      await playerPage.getByText('5', { exact: true }).click()
+      await expect(hostPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
+      await hostPage.getByRole('button', { name: 'Next Item' }).click()
+
+      // Back on the voting screen of round 2
+      await expect(hostPage.getByText('Cast your estimate')).toBeVisible({ timeout: 10000 })
+
+      // Export CSV should be visible to the host on the voting screen
+      const hostExport = hostPage.getByRole('button', { name: 'Export CSV' })
+      await expect(hostExport).toBeVisible()
+
+      // And also visible to the non-host player on their voting screen
+      await expect(playerPage.getByText('Cast your estimate')).toBeVisible({ timeout: 10000 })
+      await expect(playerPage.getByRole('button', { name: 'Export CSV' })).toBeVisible()
+
+      // Non-host can actually trigger the download
+      const playerExport = playerPage.getByRole('button', { name: 'Export CSV' })
+      await playerExport.scrollIntoViewIfNeeded()
+      const [download] = await Promise.all([
+        playerPage.waitForEvent('download'),
+        playerExport.click(),
+      ])
+      expect(download.suggestedFilename()).toMatch(/^planning-poker-[a-f0-9]+\.csv$/)
+      const content = await download.path().then((p) => {
+        // eslint-disable-next-line no-undef
+        const fs = require('fs')
+        return fs.readFileSync(p, 'utf-8')
+      })
+      expect(content).toContain('Story 1')
+      expect(content.split('\n')).toHaveLength(2) // header + 1 completed round only
+    } finally {
+      await hostCtx.close()
+      await playerCtx.close()
+    }
+  })
+
   test('CSV has no stats columns and includes non-voting players', async ({ browser }) => {
     const hostCtx = await browser.newContext()
     const voterCtx = await browser.newContext()


### PR DESCRIPTION
Extracts the history+export panel from Results into a shared
SessionHistory container mounted once at GamePane level, so any
session participant can browse prior rounds and export the CSV from
either the voting screen or the results screen — not only after a
reveal.