### PR TITLE
ci: auto-merge non-major Dependabot PRs and audit frontend deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,9 +38,17 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 3
+    groups:
+      all-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 3
+    groups:
+      all-docker:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Frontend lint + format check
         run: cd planningpoker-web && npm run lint && npm run format:check
 
+      - name: Frontend vulnerability audit
+        run: cd planningpoker-web && npm audit --audit-level=high
+
       - name: Backend format check
         run: ./gradlew spotlessCheck --no-daemon
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for non-major updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Groups github-actions and docker Dependabot updates so each ecosystem raises a single weekly PR instead of one per bump
- Adds `npm audit --audit-level=high` to the lint job so CI fails on any known high/critical advisory for declared frontend deps
- Adds `.github/workflows/dependabot-auto-merge.yml` — enables GitHub auto-merge on minor/patch Dependabot PRs once required checks pass; majors still require a manual click

Paired with newly-applied master branch protection (required checks: lint, build-web, unit-tests, e2e-tests; admins not enforced so semantic-release can still push release commits).

## Test plan
- [ ] CI passes on this PR (validates the new `npm audit` step runs cleanly in CI context)
- [ ] After merge, next Dependabot minor/patch PR auto-merges once green
- [ ] After merge, next Dependabot major PR remains open and requires manual review

🤖 Generated with [Claude Code](https://claude.com/claude-code)