### PR TITLE
ci: always auto-merge Dependabot PRs on green CI

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,14 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - name: Fetch Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Enable auto-merge for non-major updates
-        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+      - name: Enable auto-merge
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Summary
- Removes the `update-type != semver-major` gate from the Dependabot auto-merge workflow
- `dependabot/fetch-metadata` reports `update-type: null` for grouped PRs, so the blacklist check failed open — grouped majors (e.g. #92) auto-merged against intent
- Policy clarified: trust CI + branch protection as the sole gate for Dependabot PRs regardless of semver level

## Test plan
- [ ] CI passes on this PR
- [ ] Next Dependabot major PR auto-merges once green (e.g. #93 will do so after this lands if not merged sooner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)