### PR TITLE
fix(results): restore chart bar grow animation on vote

### DIFF
--- a/planningpoker-web/src/reducers/__tests__/reducer_results.test.js
+++ b/planningpoker-web/src/reducers/__tests__/reducer_results.test.js
@@ -67,6 +67,28 @@ describe('results reducer', () => {
     expect(reducer(optimistic, action)).toEqual(serverState)
   })
 
+  it('preserves state reference when VOTE echoes identical content', () => {
+    const state = [{ userName: 'alice', estimateValue: '5' }]
+    const action = {
+      type: VOTE,
+      payload: { round: 1, results: [{ userName: 'alice', estimateValue: '5' }] },
+      meta: { userName: 'alice', estimateValue: '5' },
+    }
+    expect(reducer(state, action)).toBe(state)
+  })
+
+  it('preserves state reference when RESULTS_REPLACE carries identical content', () => {
+    const state = [{ userName: 'alice', estimateValue: '5' }]
+    const action = replace(1, [{ userName: 'alice', estimateValue: '5' }])
+    expect(reducer(state, action)).toBe(state)
+  })
+
+  it('preserves state reference when RESULTS_UNION adds no new content', () => {
+    const state = [{ userName: 'alice', estimateValue: '5' }]
+    const action = union(1, [{ userName: 'alice', estimateValue: '5' }])
+    expect(reducer(state, action)).toBe(state)
+  })
+
   it('removes leaver on USER_LEFT_RECEIVED', () => {
     const existing = [
       { userName: 'alice', estimateValue: '5' },

--- a/planningpoker-web/src/reducers/reducer_results.js
+++ b/planningpoker-web/src/reducers/reducer_results.js
@@ -18,6 +18,19 @@ function mergeByUser(base, incoming) {
   return Array.from(byName.values())
 }
 
+// Preserve reference when an update carries identical content, so the chart
+// doesn't restart its in-flight bar-grow animation on the server's echo of
+// an optimistic vote.
+function sameResults(a, b) {
+  if (a === b) return true
+  if (a.length !== b.length) return false
+  const index = new Map(a.map((r) => [r.userName, r.estimateValue]))
+  for (const r of b) {
+    if (index.get(r.userName) !== r.estimateValue) return false
+  }
+  return true
+}
+
 export default function (state = initialResultsState, action) {
   switch (action.type) {
     case VOTE_OPTIMISTIC: {
@@ -27,10 +40,14 @@ export default function (state = initialResultsState, action) {
     case VOTE:
       if (action.error) return state.filter((r) => r.userName !== action.meta.userName)
       return action.payload?.results ?? state
-    case RESULTS_REPLACE:
-      return action.payload.results ?? state
-    case RESULTS_UNION:
-      return mergeByUser(state, action.payload.results ?? [])
+    case RESULTS_REPLACE: {
+      const incoming = action.payload.results ?? state
+      return sameResults(state, incoming) ? state : incoming
+    }
+    case RESULTS_UNION: {
+      const merged = mergeByUser(state, action.payload.results ?? [])
+      return sameResults(state, merged) ? state : merged
+    }
     case USER_LEFT_RECEIVED:
       return state.filter((r) => r.userName.toLowerCase() !== action.payload.leaver.toLowerCase())
     case RESET_SESSION:

--- a/planningpoker-web/src/reducers/reducer_results.js
+++ b/planningpoker-web/src/reducers/reducer_results.js
@@ -37,9 +37,12 @@ export default function (state = initialResultsState, action) {
       const { userName, estimateValue } = action.payload
       return [...state.filter((r) => r.userName !== userName), { userName, estimateValue }]
     }
-    case VOTE:
+    case VOTE: {
       if (action.error) return state.filter((r) => r.userName !== action.meta.userName)
-      return action.payload?.results ?? state
+      const incoming = action.payload?.results
+      if (!incoming) return state
+      return sameResults(state, incoming) ? state : incoming
+    }
     case RESULTS_REPLACE: {
       const incoming = action.payload.results ?? state
       return sameResults(state, incoming) ? state : incoming


### PR DESCRIPTION
The bar-grow animation regressed when commit d82e7ee removed the sameResults content-equal dedup alongside the burst pattern. Even without bursts, the server's single RESULTS echo of an optimistic vote arrives as a fresh array reference, and react-chartjs-2 treats any new data object as a change — restarting the in-flight animation and snapping the bar to its final height.

Re-introduce sameResults and apply it to RESULTS_REPLACE and RESULTS_UNION so identical payloads preserve reference and the chart keeps its animation state. VOTE_OPTIMISTIC is untouched since it genuinely mutates state.

Epoch ordering in PlayGame already filters stale messages, so the dedup only fires on true content-equal echoes — the flicker repro fixed by d82e7ee is unaffected.

## Summary

<!-- What does this PR change and why? One paragraph is fine. -->

## Test plan

<!-- How did you verify? Check off everything that applies. -->

- [ ] `npm run lint && npm run format:check` (frontend)
- [ ] `./gradlew spotlessCheck` (backend)
- [ ] `npm test` (Vitest)
- [ ] `./gradlew planningpoker-api:test` (JUnit)
- [ ] `npx playwright test` (E2E — required for UI/behaviour changes)
- [ ] Manual smoke test in a local dev server (for UI changes)

## Notes

<!-- Anything reviewers should focus on, follow-ups, migration steps, etc. -->

---

Uses [Conventional Commits](https://www.conventionalcommits.org/) — `fix:` for patches, `feat:` for minor, `!` or `BREAKING CHANGE:` for major. `chore:` / `docs:` / `test:` / `refactor:` do not trigger a release.
