### PR TITLE
fix: revert Docker major bumps (#92) — prod build broken

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build frontend
-FROM node:25-alpine AS frontend
+FROM node:22-alpine AS frontend
 WORKDIR /app/planningpoker-web
 COPY planningpoker-web/package.json planningpoker-web/package-lock.json ./
 RUN npm ci
@@ -7,7 +7,7 @@ COPY planningpoker-web/ ./
 RUN npm run build
 
 # Stage 2: Build backend
-FROM eclipse-temurin:25-jdk AS backend
+FROM eclipse-temurin:21-jdk AS backend
 WORKDIR /app
 COPY gradle/ gradle/
 COPY gradlew settings.gradle build.gradle ./
@@ -19,7 +19,7 @@ RUN chmod +x gradlew && ./gradlew planningpoker-web:jar --no-daemon
 RUN ./gradlew planningpoker-api:bootJar --no-daemon
 
 # Stage 3: Runtime
-FROM eclipse-temurin:25-jre
+FROM eclipse-temurin:21-jre
 RUN addgroup --system app && adduser --system --ingroup app app
 WORKDIR /app
 COPY --from=backend /app/planningpoker-api/build/libs/planningpoker-*.jar app.jar


### PR DESCRIPTION
## Summary
Revert of #92 to restore Railway builds.

## Root cause
#92 bumped the backend build stage to \`eclipse-temurin:25-jdk\`, but \`planningpoker-api/build.gradle\` pins the toolchain to Java 21. With only Java 25 in the container and no toolchain resolver configured, Gradle fails:

\`\`\`
Cannot find a Java installation on your machine ... matching: {languageVersion=21}
\`\`\`

5 consecutive Railway deploys failed since the merge of #92.

## Why CI missed it
CI uses \`actions/setup-java@v4\` with \`java-version: 21\` directly — it never exercises the Dockerfile. Railway is the only environment that builds from Dockerfile, and it's production. Follow-up: add a \`docker build\` step to CI so future image bumps get validated before they land.

## Test plan
- [ ] CI passes on this PR
- [ ] Railway redeploy on merge restores https://planning-poker.up.railway.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)