### PR TITLE
ci: add docker-build job and foojay toolchain resolver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,8 +198,44 @@ jobs:
           path: planningpoker-web/test-results/
           retention-days: 7
 
+  docker-build:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true
+          tags: planningpoker:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke-test container healthcheck
+        run: |
+          docker run -d --name pp -p 9000:9000 -e PORT=9000 planningpoker:ci
+          for i in $(seq 1 45); do
+            if curl -sf http://localhost:9000/actuator/health; then
+              echo "healthy"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "container failed to become healthy" >&2
+          docker logs pp
+          exit 1
+
+      - name: Cleanup container
+        if: always()
+        run: docker rm -f pp 2>/dev/null || true
+
   release:
-    needs: [unit-tests, e2e-tests]
+    needs: [unit-tests, e2e-tests, docker-build]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     permissions:

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,6 @@
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+}
+
 include 'planningpoker-web'
 include 'planningpoker-api'


### PR DESCRIPTION
## Summary
Closes the policy gap exposed by #92: Railway builds from Dockerfile, but CI never did — so a Java-version-incompatible image bump passed CI and broke prod.

**Two complementary changes:**
1. New \`docker-build\` CI job that runs \`docker build .\` against the repo Dockerfile, boots the resulting container, and polls \`/actuator/health\`. Added as a required check before \`release\`. This mirrors the build Railway runs, so future Dockerfile regressions fail CI instead of production.
2. Wires [foojay-resolver-convention](https://github.com/gradle/foojay-toolchains) into \`settings.gradle\`. Gradle's toolchain feature will now auto-provision a matching JDK from foojay.io when the container image disagrees with \`build.gradle\`'s \`languageVersion\`. Decouples Dockerfile Java version from Gradle toolchain version — #92 would have been harmless.

After this lands, I'll update branch protection to include \`docker-build\` in required status checks.

## Test plan
- [ ] CI passes — \`docker-build\` job successfully builds the image and gets a healthy response
- [ ] After merge, re-apply the eclipse-temurin 25-jdk bump (#92 redo) and confirm CI either passes (foojay resolves Java 21) or cleanly fails docker-build (if something else breaks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)