### PR TITLE
fix(api): upgrade to JUnit 6 via junit-bom

### DIFF
--- a/planningpoker-api/build.gradle
+++ b/planningpoker-api/build.gradle
@@ -39,8 +39,10 @@ dependencies {
     implementation 'org.springframework:spring-messaging'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.4'
-    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.11.4'
+    testImplementation platform('org.junit:junit-bom:6.0.3')
+    testImplementation 'org.junit.jupiter:junit-jupiter-api'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
+    testImplementation 'org.junit.platform:junit-platform-engine'
     testImplementation 'org.mockito:mockito-junit-jupiter:5.23.0'
     testImplementation 'org.mockito:mockito-core:5.23.0'
     testImplementation 'net.jqwik:jqwik:1.9.3'


### PR DESCRIPTION
## Summary
Supersedes Dependabot #78 and #82.

Those PRs bumped \`jupiter-api\` and \`jupiter-engine\` to 6.0.3 separately, but both failed CI because \`spring-boot-starter-test\` kept pulling in \`junit-platform-engine\` at 1.11.x — and Jupiter 6 requires Platform 2.x (\`ClassNotFoundException: DiscoveryIssueReporter\`).

Using the official \`junit-bom\` resolves all JUnit artifacts together:

\`\`\`gradle
testImplementation platform('org.junit:junit-bom:6.0.3')
testImplementation 'org.junit.jupiter:junit-jupiter-api'
testImplementation 'org.junit.jupiter:junit-jupiter-engine'
testImplementation 'org.junit.platform:junit-platform-engine'
\`\`\`

No test code changes — 41 unit tests pass locally.

## Test plan
- [x] \`./gradlew planningpoker-api:test\` passes locally
- [ ] CI passes (unit-tests, e2e-tests, docker-build)

Close #78 and #82 on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)