### PR TITLE
fix(api): enforce host-only access on /reset endpoint

### DIFF
--- a/planningpoker-api/src/main/java/com/richashworth/planningpoker/controller/GameController.java
+++ b/planningpoker-api/src/main/java/com/richashworth/planningpoker/controller/GameController.java
@@ -241,16 +241,17 @@ public class GameController {
   }
 
   /**
-   * Snapshots the current round's estimates into the session's completed-rounds history (if any
-   * votes were cast), clears the current estimates, and increments the round counter. Broadcasts
-   * {@code ROUND_COMPLETED_MESSAGE} (when a snapshot was taken) followed by {@code RESET_MESSAGE}
-   * so every participant's client converges on the same history and returns to the voting view.
-   * Currently any session member can trigger a reset; host-only enforcement is not applied here.
+   * Host-only action that snapshots the current round's estimates into the session's
+   * completed-rounds history (if any votes were cast), clears the current estimates, and increments
+   * the round counter. Broadcasts {@code ROUND_COMPLETED_MESSAGE} (when a snapshot was taken)
+   * followed by {@code RESET_MESSAGE} so every participant's client converges on the same history
+   * and returns to the voting view.
    *
    * <p>The optional {@code consensus} parameter lets the host supply an override (e.g. from the
    * consensus card rail); if omitted, the server falls back to the mode of the captured estimates.
    *
    * @throws IllegalArgumentException if the session is not active or the user is not a member.
+   * @throws HostActionException if the caller is not the host.
    */
   @PostMapping("reset")
   public ResetResponse reset(
@@ -261,6 +262,9 @@ public class GameController {
     Round snapshot = null;
     synchronized (sessionManager) {
       validateSessionMembership(sessionId, userName);
+      if (!userName.equalsIgnoreCase(sessionManager.getHost(sessionId))) {
+        throw new HostActionException("only the host can perform this action");
+      }
       logger.info(
           "host {} reset session {}", LogSafeIds.hash(userName), LogSafeIds.hash(sessionId));
       List<Estimate> votes = sessionManager.getResults(sessionId);

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/GameControllerTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/GameControllerTest.java
@@ -172,6 +172,7 @@ class GameControllerTest extends AbstractControllerTest {
   void testReset() {
     when(sessionManager.isSessionActive(SESSION_ID)).thenReturn(true);
     when(sessionManager.getSessionUsers(SESSION_ID)).thenReturn(Lists.newArrayList(USER_NAME));
+    when(sessionManager.getHost(SESSION_ID)).thenReturn(USER_NAME);
     when(sessionManager.getResults(SESSION_ID)).thenReturn(List.of());
     when(sessionManager.incrementAndGetRound(SESSION_ID)).thenReturn(4);
     ResetResponse response = gameController.reset(SESSION_ID, USER_NAME, null);
@@ -187,6 +188,7 @@ class GameControllerTest extends AbstractControllerTest {
   void testResetWithVotesBroadcastsRoundCompleted() {
     when(sessionManager.isSessionActive(SESSION_ID)).thenReturn(true);
     when(sessionManager.getSessionUsers(SESSION_ID)).thenReturn(Lists.newArrayList(USER_NAME));
+    when(sessionManager.getHost(SESSION_ID)).thenReturn(USER_NAME);
     List<Estimate> votes =
         List.of(new Estimate("Alice", "5"), new Estimate("Bob", "5"), new Estimate("Carol", "3"));
     when(sessionManager.getResults(SESSION_ID)).thenReturn(votes);
@@ -213,6 +215,7 @@ class GameControllerTest extends AbstractControllerTest {
   void testResetWithoutConsensusFallsBackToMode() {
     when(sessionManager.isSessionActive(SESSION_ID)).thenReturn(true);
     when(sessionManager.getSessionUsers(SESSION_ID)).thenReturn(Lists.newArrayList(USER_NAME));
+    when(sessionManager.getHost(SESSION_ID)).thenReturn(USER_NAME);
     // Two "5"s and one "3" → mode is "5"
     List<Estimate> votes =
         List.of(new Estimate("Alice", "5"), new Estimate("Bob", "5"), new Estimate("Carol", "3"));
@@ -232,6 +235,7 @@ class GameControllerTest extends AbstractControllerTest {
   void testResetWithTiedVotesPicksAlphabeticallyFirstMode() {
     when(sessionManager.isSessionActive(SESSION_ID)).thenReturn(true);
     when(sessionManager.getSessionUsers(SESSION_ID)).thenReturn(Lists.newArrayList(USER_NAME));
+    when(sessionManager.getHost(SESSION_ID)).thenReturn(USER_NAME);
     // Tie: one "3" and one "5" → alphabetically first → "3"
     List<Estimate> votes = List.of(new Estimate("Alice", "5"), new Estimate("Bob", "3"));
     when(sessionManager.getResults(SESSION_ID)).thenReturn(votes);
@@ -252,6 +256,22 @@ class GameControllerTest extends AbstractControllerTest {
     when(sessionManager.getSessionUsers(SESSION_ID)).thenReturn(Lists.newArrayList());
     assertThrows(
         IllegalArgumentException.class, () -> gameController.reset(SESSION_ID, USER_NAME, null));
+  }
+
+  @Test
+  void testResetNonHostRejected() {
+    // Issue #110: only the host may trigger a reset; a non-host session member must be rejected
+    // with HostActionException (mapped to HTTP 403 by ErrorHandler).
+    when(sessionManager.isSessionActive(SESSION_ID)).thenReturn(true);
+    when(sessionManager.getSessionUsers(SESSION_ID))
+        .thenReturn(Lists.newArrayList(USER_NAME, "Alice"));
+    when(sessionManager.getHost(SESSION_ID)).thenReturn("Alice");
+    assertThrows(
+        HostActionException.class, () -> gameController.reset(SESSION_ID, USER_NAME, null));
+    verify(sessionManager, never()).resetSession(anyString());
+    verify(sessionManager, never()).incrementAndGetRound(anyString());
+    verify(messagingUtils, never()).sendResetMessage(anyString(), anyInt());
+    verify(messagingUtils, never()).sendRoundCompletedMessage(anyString(), any(Round.class));
   }
 
   @Test
@@ -392,6 +412,7 @@ class GameControllerTest extends AbstractControllerTest {
   void testResetClearsLabel() {
     when(sessionManager.isSessionActive(SESSION_ID)).thenReturn(true);
     when(sessionManager.getSessionUsers(SESSION_ID)).thenReturn(Lists.newArrayList(USER_NAME));
+    when(sessionManager.getHost(SESSION_ID)).thenReturn(USER_NAME);
     when(sessionManager.getResults(SESSION_ID)).thenReturn(List.of());
     when(sessionManager.incrementAndGetRound(SESSION_ID)).thenReturn(1);
     gameController.reset(SESSION_ID, USER_NAME, null);

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/VotingAndResetSpecRegressionTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/VotingAndResetSpecRegressionTest.java
@@ -1,0 +1,106 @@
+package com.richashworth.planningpoker.controller;
+
+import static com.richashworth.planningpoker.common.PlanningPokerTestFixture.SESSION_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.Lists;
+import com.richashworth.planningpoker.model.CreateSessionRequest;
+import com.richashworth.planningpoker.model.Estimate;
+import com.richashworth.planningpoker.model.SessionResponse;
+import com.richashworth.planningpoker.model.VoteResponse;
+import com.richashworth.planningpoker.service.SessionManager;
+import com.richashworth.planningpoker.util.MessagingUtils;
+import java.util.List;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+
+/**
+ * Regression tests anchored to the verified VotingAndReset.tla spec.
+ *
+ * <p>These tests document known divergences between the current backend and the spec's intended
+ * behaviour. Both are expected to FAIL against the current implementation and PASS once the
+ * corresponding fixes land.
+ *
+ * <ul>
+ *   <li><b>Issue #110</b> — Spec actions {@code ResetWithVotes} / {@code ResetEmpty} require {@code
+ *       Host \in connected}; only the host may trigger reset. Current backend's {@link
+ *       GameController#reset} accepts any session member.
+ *   <li><b>Issue #111</b> — Spec action {@code UpdateVote(m, v)} replaces the member's existing
+ *       vote with the new value. Current backend's {@link VoteController#vote} silently drops the
+ *       second vote.
+ * </ul>
+ */
+class VotingAndResetSpecRegressionTest extends AbstractControllerTest {
+
+  @InjectMocks private GameController gameController;
+
+  /**
+   * Spec property: {@code ResetWithVotes} / {@code ResetEmpty} guard {@code Host \in connected}.
+   * Issue #110 — non-host caller must be rejected with {@link HostActionException} (mapped to HTTP
+   * 403 by {@link ErrorHandler}).
+   *
+   * <p>This test will FAIL until the host-only check is added to {@link GameController#reset}.
+   */
+  @Test
+  void testResetByNonHostRejectedWith403() {
+    when(sessionManager.isSessionActive(SESSION_ID)).thenReturn(true);
+    when(sessionManager.getSessionUsers(SESSION_ID))
+        .thenReturn(Lists.newArrayList("HostUser", "GuestUser"));
+    // lenient() because the current (buggy) implementation never reads getHost during reset,
+    // so a strict stub would trip UnnecessaryStubbingException. Once issue #110 is fixed and
+    // reset() consults getHost(), the stub is exercised normally.
+    lenient().when(sessionManager.getHost(SESSION_ID)).thenReturn("HostUser");
+    // Same rationale: a host-checked reset short-circuits before reaching these. Today's reset
+    // calls them, so we stub leniently to keep the test compatible with both code paths.
+    lenient().when(sessionManager.getResults(SESSION_ID)).thenReturn(List.of());
+    lenient().when(sessionManager.incrementAndGetRound(SESSION_ID)).thenReturn(1);
+
+    assertThrows(
+        HostActionException.class,
+        () -> gameController.reset(SESSION_ID, "GuestUser", null),
+        "non-host /reset must be rejected (issue #110: spec says reset is host-only)");
+  }
+
+  /**
+   * Spec property: {@code UpdateVote(m, v)} replaces the member's prior vote when {@code
+   * serverVotes[m] # v}. Issue #111 — backend currently no-ops the second vote, leaving the
+   * original value in place.
+   *
+   * <p>End-to-end check using a real {@link SessionManager}: a single member votes "5", then
+   * re-votes "8". The recorded vote in the post-call results list must be "8".
+   *
+   * <p>This test will FAIL until {@link VoteController#vote} replaces (rather than ignores) the
+   * second vote.
+   */
+  // Disabled here only because issue #111's fix lives on a sibling PR; re-enable once it lands.
+  @Disabled("Re-enable once #111 lands")
+  @Test
+  void testReVoteReplacesOriginalValue() {
+    SessionManager realSessionManager = new SessionManager();
+    MessagingUtils stubMessaging = mock(MessagingUtils.class);
+    GameController gc = new GameController(realSessionManager, stubMessaging);
+    VoteController vc = new VoteController(realSessionManager, stubMessaging);
+
+    SessionResponse session =
+        gc.createSession(new CreateSessionRequest("Alice", "fibonacci", null, true));
+    String sessionId = session.sessionId();
+
+    vc.vote(sessionId, "Alice", "5");
+    VoteResponse second = vc.vote(sessionId, "Alice", "8");
+
+    assertEquals(
+        List.of(new Estimate("Alice", "8")),
+        second.results(),
+        "re-vote must replace the existing vote (issue #111: spec UpdateVote semantics)");
+    // Sanity: also assert against the source of truth, not just the response payload.
+    assertEquals(
+        List.of(new Estimate("Alice", "8")),
+        realSessionManager.getResults(sessionId),
+        "SessionManager must reflect the replaced vote");
+  }
+}

--- a/specs/VotingAndReset.cfg
+++ b/specs/VotingAndReset.cfg
@@ -1,0 +1,43 @@
+SPECIFICATION Spec
+
+\* Deadlock checking is disabled: the bounded model can legitimately reach
+\* terminal states (all members disconnected, or serverRound = MaxRounds with
+\* no progress possible). Those are not bugs — the real system runs
+\* continuously; the bound is a model-checking artifact.
+CHECK_DEADLOCK FALSE
+
+\* State constraint to bound exploration with re-vote enabled.
+CONSTRAINT StateConstraint
+
+\* Safety (state invariants)
+INVARIANT TypeOK
+INVARIANT AllVotesLegal
+INVARIANT HistoryVotesLegal
+INVARIANT HistoryRoundsBelowCurrent
+INVARIANT NoEmptySnapshots
+INVARIANT KnownRoundBoundedByServer
+INVARIANT ViewValuesLegal
+
+\* Action properties (temporal safety — must use PROPERTY, not INVARIANT)
+PROPERTY RoundMonotonic
+PROPERTY VotesClearedAfterReset
+
+\* Liveness
+\* ResetEventuallyObserved is a "leads-to" property requiring exhaustive liveness
+\* checking on top of the safety state space. With re-vote enabled, the inflight
+\* set semantics produce a state space too large for exhaustive liveness checking
+\* in reasonable time (>5 min). Liveness has been confirmed via random simulation
+\* (200 traces × depth 100 = 9k+ states, no violations). Uncomment to verify
+\* exhaustively at smaller bounds (e.g., LegalValues = {1}).
+\* PROPERTY ResetEventuallyObserved
+
+\* Constants — small finite domains for tractable model checking.
+\* NOTE: Symmetry is intentionally NOT used here — the spec contains PROPERTY
+\* lines and TLC's symmetry reduction is unsound with liveness/temporal
+\* properties. Also, Host singles out one member, breaking interchangeability.
+CONSTANT
+    Members = {m1, m2}
+    Host = m1
+    LegalValues = {1, 2}
+    MaxRounds = 2
+    NoVote = NoVote

--- a/specs/VotingAndReset.summary.md
+++ b/specs/VotingAndReset.summary.md
@@ -1,0 +1,164 @@
+## System: Planning Poker — Voting & Reset Round
+
+### Entities
+
+- **Session**: a single planning-poker session (the only one in the model)
+  - Type: resource
+  - Count: fixed at 1
+  - States: active (the only modeled state)
+  - Initial state: active
+
+- **Member**: a registered participant in the session
+  - Type: actor
+  - Count: fixed N (default 3 for the model)
+  - States: connected, disconnected
+  - Initial state: connected
+
+- **Host**: the privileged member who can trigger reset
+  - Type: role (designation among members)
+  - Count: exactly 1
+  - States: assigned to one member for the lifetime of the model
+  - Initial state: a designated host member is chosen at start
+
+- **Vote (estimate)**: a (member, value) record for the current round
+  - Type: resource (per-member, per-round)
+  - Count: at most 1 per member per round
+  - States: absent, cast(value)
+  - Initial state: absent for every member
+
+- **Round**: a monotonic counter for the session, plus history
+  - Type: resource
+  - Count: 1 counter per session; history grows by ≤1 per non-empty reset
+  - States: integer ≥ 0; history is a list of completed-round snapshots
+  - Initial state: counter = 0, history = empty
+
+- **Broadcast (in-flight message)**: a server-to-client message about a state change
+  - Type: resource (multiset of pending messages)
+  - Count: bounded by activity; messages are consumed when delivered
+  - States: pending, delivered (consumed). Each message carries its round number.
+  - Initial state: empty
+
+### Transitions
+
+- **Member: cast vote (first-time)**
+  - Trigger: connected member casts a vote of value v in legalValues
+  - Guard: member is connected; v in legalValues; member has no vote in current round
+  - Effect: record (member, v) at current round; emit RESULTS broadcast for current round
+
+- **Member: update vote (re-vote)**
+  - Trigger: connected member casts a different value v' in same round
+  - Guard: member is connected; v' in legalValues; member already has a vote in current round
+  - Effect: replace member's vote with v'; emit RESULTS broadcast for current round
+
+- **Host: reset round (with votes)**
+  - Trigger: host triggers reset
+  - Guard: actor is the host; host is connected (a disconnected host cannot reset — needs an active session to call the API); round has at least one cast vote
+  - Effect: snapshot {round, votes} into history; clear all votes; increment round counter; emit RESET broadcast for new round
+
+- **Host: reset round (empty)**
+  - Trigger: host triggers reset
+  - Guard: actor is the host; host is connected; round has zero cast votes
+  - Effect: do not snapshot; clear (no-op); increment round counter; emit RESET broadcast for new round
+
+- **Member: deliver broadcast (RESULTS, newer round)**
+  - Trigger: a RESULTS broadcast for round R > member's known round is delivered
+  - Effect: member's known round = R; member's view of votes = broadcast's votes
+
+- **Member: deliver broadcast (RESULTS, same round)**
+  - Trigger: a RESULTS broadcast for round R = member's known round is delivered
+  - Effect: merge per-member — for each member listed in the broadcast (with a legal value), set the receiver's view of that member's vote to the broadcast value (overwriting any prior view of that member at this round); for members not in the broadcast, preserve the existing view. (Real-world note: RESULTS broadcasts only ever carry members who have voted, so this is effectively "broadcast augments view with newly-voted members.")
+
+- **Member: deliver broadcast (RESULTS, older round)**
+  - Trigger: a RESULTS broadcast for round R < member's known round is delivered
+  - Effect: ignored (no state change)
+
+- **Member: deliver broadcast (RESET, newer round)**
+  - Trigger: a RESET broadcast for round R > member's known round is delivered
+  - Effect: member's known round = R; member's view of votes = empty
+
+- **Member: deliver broadcast (RESET, equal-or-older round)**
+  - Trigger: a RESET broadcast for round R <= member's known round is delivered
+  - Effect: ignored
+
+- **Member: disconnect**
+  - Trigger: member's WS connection drops
+  - Effect: member becomes disconnected; pending broadcasts targeted at them are dropped
+
+- **Member: lose broadcast**
+  - Trigger: a pending broadcast is dropped before delivery
+  - Effect: broadcast removed without being applied (models lossy delivery)
+
+### Constraints
+
+**Should never happen:**
+- A member has more than one vote recorded in the same round
+- A vote is recorded with a value not in legalValues
+- The round counter decreases
+- A snapshot in history exists for a round number >= the current round counter
+- A non-host triggers a reset
+- An empty round produces a snapshot in history
+- A member's known round exceeds the server's round counter
+- A member's view of votes contains a value not in legalValues
+
+**Must always be true:**
+- The round counter is monotonically non-decreasing throughout the session
+- After a reset, the previous round's votes are cleared from the server's state
+- Every snapshot in history corresponds to a round strictly less than the current round counter
+- The set of currently cast votes is a subset of (members x legalValues)
+- For every snapshot in history, its votes are a subset of (members x legalValues)
+- A member's known round is <= the server's round
+- For every still-connected member, their known round and view of votes is consistent with some RESULTS or RESET broadcast that the server has emitted for that round (or with the initial state)
+
+**Must eventually happen (conditional on staying connected):**
+- After a member casts or updates a vote, every still-connected member eventually observes that vote (via delivered broadcast)
+- After the host triggers a reset, every still-connected member eventually advances to the new round (their known round = server's round) and shows no votes for the new round
+
+### Concurrency
+- Simultaneous actors: any member can act at any time (cast or update vote); the host can additionally reset; broadcasts to different members can be delivered in any interleaving
+- Conflict resolution: every server-side action (vote, reset) is atomic — it reads the round counter, mutates state, and emits one broadcast as a single indivisible step. Effective execution is some serialization of concurrent requests.
+- Atomicity:
+  - Vote check + register (or replace) is atomic
+  - Snapshot + clear + increment + emit-broadcast on reset is atomic
+  - Per-member broadcast delivery is atomic (the member's known round and view advance together)
+
+### Resource Bounds
+- N members: small fixed parameter for the model (default 3)
+- legalValues: small fixed set (default {1, 2, 3})
+- Round counter: unbounded; model checker explores up to a small depth (MaxRounds = 4)
+- History: grows by <=1 per non-empty reset, bounded by depth
+- Broadcast queue: at most one pending RESULTS broadcast per cast/update, plus one RESET broadcast per reset; bounded by depth
+
+### Failure Modes
+
+- **Lost broadcast**: a pending broadcast is dropped before delivery. Effect: still-connected members may stay stale until another broadcast arrives that supersedes the lost one. Spectators (members who never act) may stay permanently stale; the implementation's /refresh fallback only triggers after the member's own vote.
+- **Member disconnect**: member's pending broadcasts are dropped; member is excluded from liveness. Reconnection and refresh are out of scope for this slice.
+- **Stale broadcast arrival**: a broadcast for a strictly older round is delivered. Effect: ignored by the receiving member's reconciliation logic — no state change.
+- **Duplicated broadcast**: the same broadcast is delivered more than once. Effect: same-round delivery is union (idempotent for RESULTS); newer-round delivery is replace (idempotent if applied with same payload); RESET applied at equal round is ignored. No state divergence.
+- **Vote-during-reset race**: vote and reset serialize via the lock. If vote-then-reset, the vote is captured in the snapshot. If reset-then-vote, the vote attaches to the new round. No state inconsistency, but the user-attribution (which question their vote was for) depends on serialization order.
+- **Host triple-click reset**: three resets serialize; each bumps the round. Empty rounds are skipped from history. No inconsistency.
+
+### Fairness
+- **After a vote, every still-connected member eventually observes it**: weak fairness on broadcast delivery (assumes the broadcast channel eventually delivers to still-connected subscribers).
+- **After a reset, every still-connected member eventually advances**: weak fairness on broadcast delivery.
+- **No strong-fairness properties identified** — actions don't get preempted; they atomically complete.
+
+### Termination
+- **Terminates**: no — the system runs continuously. Sessions don't have a "completed" terminal state; they accumulate rounds indefinitely (until evicted, which is out of scope for this slice).
+- For the model checker, exploration terminates by the bounded round depth (MaxRounds).
+
+### Implementation Detail (intended behavior — diverges from current backend)
+
+- **Reset is host-only** in the spec. The current backend allows any session member to call /reset (with an explicit code comment acknowledging this). The UI gates the reset button to host-only via `isAdmin` check in `Results.jsx`. The spec models the intended behavior; the backend's missing host check is a known gap to flag.
+- **Re-vote replaces** the member's existing vote. The current backend silently drops a second vote (returns current state unchanged). The spec models the intended behavior (matches standard planning-poker UX); the backend's silent-drop is a known bug to flag.
+
+### Verification Status (as of 2026-04-25)
+
+- **Model parameters:** Members={m1,m2}, Host=m1, LegalValues={1,2}, MaxRounds=2; state constraint Cardinality(inflight) <= 4
+- **Safety: VERIFIED exhaustively.** TLC explored 18.4M distinct states (106M total) in ~2 minutes. All 7 invariants hold:
+  - TypeOK, AllVotesLegal, HistoryVotesLegal, HistoryRoundsBelowCurrent, NoEmptySnapshots, KnownRoundBoundedByServer, ViewValuesLegal
+  - Action properties RoundMonotonic and VotesClearedAfterReset also hold.
+- **Liveness: confirmed via random simulation** (200 traces × depth 100 ≈ 9000 states, no violations of ResetEventuallyObserved). Exhaustive liveness checking exceeds the practical time budget at the chosen bounds because the inflight set semantics generate large state spaces. Re-enable PROPERTY ResetEventuallyObserved in the .cfg and run with smaller bounds (e.g., LegalValues={1}) for exhaustive liveness verification.
+- **Modeling limitations:**
+  - `emitted` history variable was dropped to keep the state space tractable; consequently the `ViewConsistentWithEmitted` invariant (every observed view is consistent with some emitted broadcast) is not currently checked. The other 7 invariants still ensure value-level legality and structural correctness.
+  - Lossy broadcast delivery (`LoseBroadcast`) is not modeled; STOMP within a connected channel is treated as reliable, matching real TCP behavior.
+  - Reconnect/refresh paths (8s vote-fallback, /sessionUsers probe on reconnect) are out of scope for this slice.

--- a/specs/VotingAndReset.tla
+++ b/specs/VotingAndReset.tla
@@ -1,0 +1,305 @@
+---- MODULE VotingAndReset ----
+\* Planning Poker — Voting & Reset Round (intended behavior)
+\* Models a single session with a fixed member set, a designated host,
+\* a monotonic round counter, in-flight broadcasts (RESULTS / RESET),
+\* and per-member views reconciled by round/epoch.
+\*
+\* Note: this spec intentionally captures the *intended* behavior, which
+\* differs from the current backend in two ways:
+\*   - reset is host-only here (backend allows any session member)
+\*   - re-vote replaces the prior value (backend silently drops it)
+
+EXTENDS Integers, Sequences, FiniteSets
+
+CONSTANTS
+    Members,        \* set of member identifiers (e.g. {m1, m2})
+    Host,           \* the designated host (Host \in Members)
+    LegalValues,    \* set of legal vote values (e.g. {1, 2})
+    MaxRounds,      \* upper bound on the server's round counter (state-space cap)
+    NoVote          \* sentinel for "no value cast" (declare as TLC model value
+                    \*   in .cfg so it never type-mixes with LegalValues elements)
+
+\* Broadcast kinds
+ResultsKind == "RESULTS"
+ResetKind   == "RESET"
+
+VARIABLES
+    serverRound,        \* server's current round counter (Nat)
+    serverVotes,        \* serverVotes[m] = LegalValues \cup {NoVote} for current round
+    history,            \* sequence of completed-round snapshots
+    connected,          \* set of currently connected members
+    memberKnownRound,   \* memberKnownRound[m] = the latest round m has observed
+    memberView,         \* memberView[m][m2] = m's view of m2's vote
+    inflight            \* set of pending broadcasts; each targets a specific member
+
+vars == << serverRound, serverVotes, history, connected,
+           memberKnownRound, memberView, inflight >>
+
+\* --- Helpers ---
+
+SnapshotType ==
+    [ round : 0..MaxRounds,
+      votes : [Members -> LegalValues \cup {NoVote}] ]
+
+\* A broadcast envelope. Each broadcast targets one member (per-subscriber delivery).
+BroadcastType ==
+    [ kind   : {ResultsKind, ResetKind},
+      target : Members,
+      round  : 0..MaxRounds,
+      votes  : [Members -> LegalValues \cup {NoVote}] ]
+
+\* Emit one broadcast per currently-connected member. (STOMP only delivers to
+\* active subscribers; broadcasts targeted at disconnected members would
+\* never be consumed and would falsify liveness.)
+ResultsBroadcasts(r, vfun, conn) ==
+    { [kind |-> ResultsKind, target |-> m, round |-> r, votes |-> vfun]
+        : m \in conn }
+
+EmptyVotes == [ m \in Members |-> NoVote ]
+
+ResetBroadcasts(r, conn) ==
+    { [kind |-> ResetKind, target |-> m, round |-> r, votes |-> EmptyVotes]
+        : m \in conn }
+
+HasAnyVote(vfun) == \E m \in Members : vfun[m] \in LegalValues
+
+\* --- Type Invariant ---
+\*
+\* Note: "at most one vote per member per round" is structurally enforced
+\* by serverVotes being a function from Members.
+
+TypeOK ==
+    /\ serverRound \in 0..MaxRounds
+    /\ serverVotes \in [Members -> LegalValues \cup {NoVote}]
+    /\ history \in Seq(SnapshotType)
+    /\ connected \subseteq Members
+    /\ memberKnownRound \in [Members -> 0..MaxRounds]
+    /\ memberView \in [Members -> [Members -> LegalValues \cup {NoVote}]]
+    /\ inflight \subseteq BroadcastType
+
+\* --- State Constraint (model-checking aid) ---
+\* Bounds the inflight queue to keep the state space tractable. With re-vote
+\* enabled, broadcasts can pile up faster than they're delivered; this caps
+\* exploration at "reasonable" backlog sizes.
+StateConstraint == Cardinality(inflight) <= 4
+
+\* --- Initial State ---
+
+Init ==
+    /\ serverRound = 0
+    /\ serverVotes = [m \in Members |-> NoVote]
+    /\ history = << >>
+    /\ connected = Members
+    /\ memberKnownRound = [m \in Members |-> 0]
+    /\ memberView = [m \in Members |-> [m2 \in Members |-> NoVote]]
+    /\ inflight = {}
+
+\* --- Actions ---
+
+\* Member casts a first-time vote in the current round.
+CastVote(m, v) ==
+    /\ m \in connected
+    /\ v \in LegalValues
+    /\ serverVotes[m] = NoVote
+    /\ LET newVotes  == [serverVotes EXCEPT ![m] = v]
+           newBcasts == ResultsBroadcasts(serverRound, newVotes, connected)
+       IN  /\ serverVotes' = newVotes
+           /\ inflight' = inflight \cup newBcasts
+    /\ UNCHANGED << serverRound, history, connected,
+                    memberKnownRound, memberView >>
+
+\* Member updates an existing vote in the current round (re-vote replaces).
+UpdateVote(m, v) ==
+    /\ m \in connected
+    /\ v \in LegalValues
+    /\ serverVotes[m] \in LegalValues
+    /\ serverVotes[m] # v
+    /\ LET newVotes  == [serverVotes EXCEPT ![m] = v]
+           newBcasts == ResultsBroadcasts(serverRound, newVotes, connected)
+       IN  /\ serverVotes' = newVotes
+           /\ inflight' = inflight \cup newBcasts
+    /\ UNCHANGED << serverRound, history, connected,
+                    memberKnownRound, memberView >>
+
+\* Host resets a non-empty round: snapshot, clear, increment, broadcast.
+\* Guard "Host \in connected" matches the summary's precondition that the
+\* host must be connected to call the reset API.
+ResetWithVotes ==
+    /\ serverRound + 1 \in 0..MaxRounds
+    /\ HasAnyVote(serverVotes)
+    /\ Host \in connected
+    /\ LET snap     == [round |-> serverRound, votes |-> serverVotes]
+           newRound == serverRound + 1
+           newBcasts == ResetBroadcasts(newRound, connected)
+       IN  /\ history' = Append(history, snap)
+           /\ serverVotes' = EmptyVotes
+           /\ serverRound' = newRound
+           /\ inflight' = inflight \cup newBcasts
+    /\ UNCHANGED << connected, memberKnownRound, memberView >>
+
+\* Host resets an empty round: no snapshot, increment, broadcast.
+ResetEmpty ==
+    /\ serverRound + 1 \in 0..MaxRounds
+    /\ ~ HasAnyVote(serverVotes)
+    /\ Host \in connected
+    /\ LET newRound  == serverRound + 1
+           newBcasts == ResetBroadcasts(newRound, connected)
+       IN  /\ serverRound' = newRound
+           /\ inflight' = inflight \cup newBcasts
+    /\ UNCHANGED << serverVotes, history, connected,
+                    memberKnownRound, memberView >>
+
+\* Member m delivers a RESULTS broadcast b targeted at m, where b.round > known.
+DeliverResultsNewer(m, b) ==
+    /\ b \in inflight
+    /\ b.kind = ResultsKind
+    /\ b.target = m
+    /\ m \in connected
+    /\ b.round > memberKnownRound[m]
+    /\ memberKnownRound' = [memberKnownRound EXCEPT ![m] = b.round]
+    /\ memberView' = [memberView EXCEPT ![m] = b.votes]
+    /\ inflight' = inflight \ {b}
+    /\ UNCHANGED << serverRound, serverVotes, history, connected >>
+
+\* Member m delivers a RESULTS broadcast b at the same round: merge per-member.
+\* (Last-writer-per-member: broadcasts at the same round derive from the same
+\* monotonically-evolving serverVotes, so overwriting per-member with the
+\* broadcast value preserves consistency at that round.)
+DeliverResultsSame(m, b) ==
+    /\ b \in inflight
+    /\ b.kind = ResultsKind
+    /\ b.target = m
+    /\ m \in connected
+    /\ b.round = memberKnownRound[m]
+    /\ LET unioned ==
+            [ m2 \in Members |->
+                IF b.votes[m2] \in LegalValues
+                THEN b.votes[m2]
+                ELSE memberView[m][m2] ]
+       IN  memberView' = [memberView EXCEPT ![m] = unioned]
+    /\ inflight' = inflight \ {b}
+    /\ UNCHANGED << serverRound, serverVotes, history, connected,
+                    memberKnownRound >>
+
+\* Member m delivers a stale RESULTS broadcast: ignore (drop it).
+DeliverResultsOlder(m, b) ==
+    /\ b \in inflight
+    /\ b.kind = ResultsKind
+    /\ b.target = m
+    /\ b.round < memberKnownRound[m]
+    /\ inflight' = inflight \ {b}
+    /\ UNCHANGED << serverRound, serverVotes, history, connected,
+                    memberKnownRound, memberView >>
+
+\* Member m delivers a RESET broadcast at a strictly newer round.
+DeliverResetNewer(m, b) ==
+    /\ b \in inflight
+    /\ b.kind = ResetKind
+    /\ b.target = m
+    /\ m \in connected
+    /\ b.round > memberKnownRound[m]
+    /\ memberKnownRound' = [memberKnownRound EXCEPT ![m] = b.round]
+    /\ memberView' = [memberView EXCEPT ![m] = EmptyVotes]
+    /\ inflight' = inflight \ {b}
+    /\ UNCHANGED << serverRound, serverVotes, history, connected >>
+
+\* Member m delivers a RESET broadcast at <= known round: ignore.
+DeliverResetStale(m, b) ==
+    /\ b \in inflight
+    /\ b.kind = ResetKind
+    /\ b.target = m
+    /\ b.round <= memberKnownRound[m]
+    /\ inflight' = inflight \ {b}
+    /\ UNCHANGED << serverRound, serverVotes, history, connected,
+                    memberKnownRound, memberView >>
+
+\* Member disconnects. Pending broadcasts targeted at them are dropped.
+Disconnect(m) ==
+    /\ m \in connected
+    /\ connected' = connected \ {m}
+    /\ inflight' = { b \in inflight : b.target # m }
+    /\ UNCHANGED << serverRound, serverVotes, history,
+                    memberKnownRound, memberView >>
+
+\* --- Next-State Relation ---
+
+Next ==
+    \/ \E m \in Members, v \in LegalValues : CastVote(m, v)
+    \/ \E m \in Members, v \in LegalValues : UpdateVote(m, v)
+    \/ ResetWithVotes
+    \/ ResetEmpty
+    \/ \E m \in Members, b \in inflight : DeliverResultsNewer(m, b)
+    \/ \E m \in Members, b \in inflight : DeliverResultsSame(m, b)
+    \/ \E m \in Members, b \in inflight : DeliverResultsOlder(m, b)
+    \/ \E m \in Members, b \in inflight : DeliverResetNewer(m, b)
+    \/ \E m \in Members, b \in inflight : DeliverResetStale(m, b)
+    \/ \E m \in Members : Disconnect(m)
+
+\* --- Specification ---
+\*
+\* Per-action weak fairness on each member's deliver actions.
+\* No fairness on Disconnect — it's an environment failure.
+Spec ==
+    /\ Init
+    /\ [][Next]_vars
+    /\ \A m \in Members : WF_vars(\E b \in inflight : DeliverResultsNewer(m, b))
+    /\ \A m \in Members : WF_vars(\E b \in inflight : DeliverResultsSame(m, b))
+    /\ \A m \in Members : WF_vars(\E b \in inflight : DeliverResultsOlder(m, b))
+    /\ \A m \in Members : WF_vars(\E b \in inflight : DeliverResetNewer(m, b))
+    /\ \A m \in Members : WF_vars(\E b \in inflight : DeliverResetStale(m, b))
+
+\* --- Safety Invariants ---
+
+AllVotesLegal ==
+    \A m \in Members :
+        (serverVotes[m] # NoVote) => serverVotes[m] \in LegalValues
+
+HistoryVotesLegal ==
+    \A i \in 1..Len(history) :
+        \A m \in Members :
+            (history[i].votes[m] # NoVote) => history[i].votes[m] \in LegalValues
+
+HistoryRoundsBelowCurrent ==
+    \A i \in 1..Len(history) : history[i].round < serverRound
+
+NoEmptySnapshots ==
+    \A i \in 1..Len(history) :
+        \E m \in Members : history[i].votes[m] \in LegalValues
+
+KnownRoundBoundedByServer ==
+    \A m \in Members : memberKnownRound[m] <= serverRound
+
+ViewValuesLegal ==
+    \A m \in Members, m2 \in Members :
+        memberView[m][m2] \in LegalValues \cup {NoVote}
+
+\* --- Action Properties (temporal safety) ---
+
+\* The round counter never decreases on any step.
+RoundMonotonic == [][serverRound' >= serverRound]_vars
+
+\* Whenever a reset action fires, the post-state has all votes cleared.
+VotesClearedAfterReset ==
+    [][(ResetWithVotes \/ ResetEmpty) => serverVotes' = EmptyVotes]_vars
+
+\* --- Liveness Properties ---
+
+\* If the server is at round r and a connected member m is behind, eventually
+\* m catches up to round r (or beyond) or disconnects. By DeliverResetNewer's
+\* effect, when m's known round becomes r, m's view is set to EmptyVotes --
+\* covering the summary's "advance to new round AND show no votes" requirement
+\* at the moment of delivery.
+\*
+\* Note: a stronger value-level liveness claim ("connected members eventually
+\* see every cast vote in their view") cannot be expressed cleanly in TLA+
+\* under the set semantics for inflight broadcasts: an infinite re-vote
+\* oscillation can keep an identical RESULTS broadcast in the set indefinitely
+\* even when each individual emit reaches the target in bounded real time.
+\* The genuinely-checkable safety claim is ViewConsistentWithEmitted: every
+\* observed view is consistent with some broadcast the server actually emitted.
+ResetEventuallyObserved ==
+    \A r \in 1..MaxRounds, m \in Members :
+        (serverRound >= r /\ memberKnownRound[m] < r /\ m \in connected)
+        ~> (memberKnownRound[m] >= r \/ m \notin connected)
+
+====


### PR DESCRIPTION
Closes #110.

## Summary

- Adds a host check to `GameController.reset` analogous to the ones already in `kick`, `promote`, and `setLabel`. A non-host session member who hits `POST /reset` directly (curl, devtools, stale tab) now gets a 403 `HostActionException` instead of silently advancing the round and clobbering everyone else's votes.
- Removes the in-code "any session member can trigger a reset" comment that explicitly acknowledged this divergence from the intent.
- Adds `testResetNonHostRejected` in `GameControllerTest`, plus the spec-anchored regression test `testResetByNonHostRejectedWith403` in the new `VotingAndResetSpecRegressionTest`. Both now pass.
- Brings in the TLA+ slice (`specs/VotingAndReset.{tla,cfg,summary.md}`) that surfaced this bug; the spec models reset's guard as `Host \in connected`, which this fix now matches.

## Cross-PR coordination — issue #111

A sibling regression test in the same file, `testReVoteReplacesOriginalValue`, asserts the fix for **issue #111** (re-vote replaces, currently a no-op). That fix is on a separate PR, so the test is marked `@Disabled("Re-enable once #111 lands")` here to keep CI green. It will be re-enabled in a follow-up PR after both #110 and #111 merge.

## Test plan

- [x] `./gradlew planningpoker-api:test` — all 145 tests pass; 1 skipped (the `@Disabled` cross-PR #111 test)
- [x] `./gradlew spotlessCheck` — clean
- [x] New `testResetNonHostRejected` asserts non-host gets `HostActionException` and that no reset side-effects fire (no `resetSession`, no `incrementAndGetRound`, no `sendResetMessage`, no `sendRoundCompletedMessage`)
- [x] Spec regression `testResetByNonHostRejectedWith403` flips from FAIL → PASS with this fix
- [x] Existing reset tests (`testReset`, `testResetWithVotesBroadcastsRoundCompleted`, etc.) updated to stub `sessionManager.getHost(...)` returning the same user — no behavioural regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)