### PR TITLE
fix(api): re-vote replaces existing estimate, closes #111

### DIFF
--- a/planningpoker-api/src/main/java/com/richashworth/planningpoker/controller/VoteController.java
+++ b/planningpoker-api/src/main/java/com/richashworth/planningpoker/controller/VoteController.java
@@ -26,9 +26,11 @@ public class VoteController {
   }
 
   /**
-   * Registers a vote for {@code userName} in {@code sessionId}. Re-voting is a no-op within the
-   * same round; subsequent rounds are tracked via {@code SessionManager#incrementAndGetRound}.
-   * Broadcasts the updated results to {@code /topic/results/{sessionId}} after the write.
+   * Registers a vote for {@code userName} in {@code sessionId}. Re-voting within the same round
+   * replaces the prior estimate (matching the spec's {@code UpdateVote} action — see {@code
+   * specs/VotingAndReset.tla}). Subsequent rounds are tracked via {@code
+   * SessionManager#incrementAndGetRound}. Broadcasts the updated results to {@code
+   * /topic/results/{sessionId}} after the write.
    *
    * @throws IllegalArgumentException if the estimate is not in the session's legal values, the
    *     session is inactive, or the user is not a member of the session.
@@ -57,10 +59,9 @@ public class VoteController {
           LogSafeIds.hash(userName),
           LogSafeIds.hash(sessionId),
           LogSafeIds.hash(estimateValue));
-      if (!CollectionUtils.containsUserEstimate(sessionManager.getResults(sessionId), userName)) {
-        final Estimate estimate = new Estimate(userName, estimateValue);
-        sessionManager.registerEstimate(sessionId, estimate);
-      }
+      // registerEstimate is an upsert: it replaces any prior estimate this user already cast in
+      // the current round. See SessionManager#registerEstimate.
+      sessionManager.registerEstimate(sessionId, new Estimate(userName, estimateValue));
       round = sessionManager.getRound(sessionId);
       results = sessionManager.getResults(sessionId);
     }

--- a/planningpoker-api/src/main/java/com/richashworth/planningpoker/service/SessionManager.java
+++ b/planningpoker-api/src/main/java/com/richashworth/planningpoker/service/SessionManager.java
@@ -128,8 +128,22 @@ public class SessionManager {
     touchSession(sessionId);
   }
 
+  /**
+   * Registers an estimate for a user in the given session, replacing any prior estimate the same
+   * user submitted in the current round. The replace + put is performed atomically against the
+   * synchronized multimap so concurrent callers cannot observe a transient state with both the old
+   * and new values, nor with neither. Matches users case-insensitively, mirroring {@link
+   * #removeUser(String, String)}.
+   */
   public void registerEstimate(final String sessionId, final Estimate estimate) {
-    sessionEstimates.put(sessionId, estimate);
+    // synchronized(sessionEstimates) is the documented way to make a compound operation atomic on
+    // a Multimaps.synchronizedListMultimap — the per-method locks alone are not sufficient.
+    synchronized (sessionEstimates) {
+      sessionEstimates
+          .get(sessionId)
+          .removeIf(e -> e.userName().equalsIgnoreCase(estimate.userName()));
+      sessionEstimates.put(sessionId, estimate);
+    }
     touchSession(sessionId);
   }
 

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/VoteControllerTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/VoteControllerTest.java
@@ -27,15 +27,13 @@ class VoteControllerTest extends AbstractControllerTest {
     when(sessionManager.getSessionUsers(SESSION_ID)).thenReturn(Lists.newArrayList(USER_NAME));
     when(sessionManager.getRound(SESSION_ID)).thenReturn(2);
     List<Estimate> afterVote = List.of(ESTIMATE);
-    // getResults is called twice: once in containsUserEstimate check, again when building response
-    when(sessionManager.getResults(SESSION_ID)).thenReturn(List.of()).thenReturn(afterVote);
+    when(sessionManager.getResults(SESSION_ID)).thenReturn(afterVote);
     VoteResponse response = voteController.vote(SESSION_ID, USER_NAME, ESTIMATE_VALUE);
     assertEquals(2, response.round());
     assertEquals(afterVote, response.results());
     inOrder.verify(sessionManager, times(1)).getSessionLegalValues(SESSION_ID);
     inOrder.verify(sessionManager, times(1)).isSessionActive(SESSION_ID);
     inOrder.verify(sessionManager, times(1)).getSessionUsers(SESSION_ID);
-    inOrder.verify(sessionManager, times(1)).getResults(SESSION_ID);
     inOrder.verify(sessionManager, times(1)).registerEstimate(SESSION_ID, ESTIMATE);
     inOrder.verify(sessionManager, times(1)).getRound(SESSION_ID);
     inOrder.verify(sessionManager, times(1)).getResults(SESSION_ID);
@@ -43,19 +41,31 @@ class VoteControllerTest extends AbstractControllerTest {
     inOrder.verifyNoMoreInteractions();
   }
 
+  /**
+   * Re-voting in the same round must replace the prior estimate (issue #111). The controller is no
+   * longer responsible for dedup — every vote unconditionally upserts via {@code
+   * SessionManager#registerEstimate}.
+   */
   @Test
-  void testVoteUserAlreadyVoted() {
+  void testReVoteReplacesExistingEstimate() {
+    String newValue = "8";
+    Estimate newEstimate = new Estimate(USER_NAME, newValue);
     when(sessionManager.getSessionLegalValues(SESSION_ID)).thenReturn(STORY_POINT_VALUES);
     when(sessionManager.isSessionActive(SESSION_ID)).thenReturn(true);
     when(sessionManager.getSessionUsers(SESSION_ID)).thenReturn(Lists.newArrayList(USER_NAME));
-    when(sessionManager.getResults(SESSION_ID)).thenReturn(Lists.newArrayList(ESTIMATE));
     when(sessionManager.getRound(SESSION_ID)).thenReturn(1);
-    VoteResponse response = voteController.vote(SESSION_ID, USER_NAME, ESTIMATE_VALUE);
+    // Source-of-truth post-upsert results: the new estimate has replaced the old one.
+    when(sessionManager.getResults(SESSION_ID)).thenReturn(List.of(newEstimate));
+
+    VoteResponse response = voteController.vote(SESSION_ID, USER_NAME, newValue);
+
     assertEquals(1, response.round());
+    assertEquals(List.of(newEstimate), response.results());
     inOrder.verify(sessionManager, times(1)).getSessionLegalValues(SESSION_ID);
     inOrder.verify(sessionManager, times(1)).isSessionActive(SESSION_ID);
     inOrder.verify(sessionManager, times(1)).getSessionUsers(SESSION_ID);
-    inOrder.verify(sessionManager, times(1)).getResults(SESSION_ID);
+    // Crucial: registerEstimate is invoked even though a prior estimate exists for this user.
+    inOrder.verify(sessionManager, times(1)).registerEstimate(SESSION_ID, newEstimate);
     inOrder.verify(sessionManager, times(1)).getRound(SESSION_ID);
     inOrder.verify(sessionManager, times(1)).getResults(SESSION_ID);
     inOrder.verify(messagingUtils, times(1)).sendResultsMessage(SESSION_ID);

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/VotingAndResetSpecRegressionTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/VotingAndResetSpecRegressionTest.java
@@ -15,7 +15,6 @@ import com.richashworth.planningpoker.model.VoteResponse;
 import com.richashworth.planningpoker.service.SessionManager;
 import com.richashworth.planningpoker.util.MessagingUtils;
 import java.util.List;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 
@@ -77,8 +76,6 @@ class VotingAndResetSpecRegressionTest extends AbstractControllerTest {
    * <p>This test will FAIL until {@link VoteController#vote} replaces (rather than ignores) the
    * second vote.
    */
-  // Disabled here only because issue #111's fix lives on a sibling PR; re-enable once it lands.
-  @Disabled("Re-enable once #111 lands")
   @Test
   void testReVoteReplacesOriginalValue() {
     SessionManager realSessionManager = new SessionManager();

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/service/SessionManagerTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/service/SessionManagerTest.java
@@ -64,6 +64,50 @@ class SessionManagerTest {
     assertEquals(Lists.newArrayList(estimate), results);
   }
 
+  /**
+   * Issue #111: registerEstimate is an upsert. A second call for the same user must replace the
+   * prior value rather than append a duplicate.
+   */
+  @Test
+  void testRegisterEstimateReplacesExistingForSameUser() {
+    final String sessionId = sessionManager.createSession();
+    sessionManager.registerEstimate(sessionId, new Estimate("Alice", "5"));
+    sessionManager.registerEstimate(sessionId, new Estimate("Alice", "8"));
+
+    List<Estimate> results = sessionManager.getResults(sessionId);
+    assertEquals(1, results.size(), "re-vote must not append a duplicate row");
+    assertEquals(new Estimate("Alice", "8"), results.get(0), "re-vote must keep the new value");
+  }
+
+  /**
+   * Issue #111: the upsert match is case-insensitive (matching {@link
+   * SessionManager#removeUser(String, String)}'s behaviour).
+   */
+  @Test
+  void testRegisterEstimateUpsertIsCaseInsensitive() {
+    final String sessionId = sessionManager.createSession();
+    sessionManager.registerEstimate(sessionId, new Estimate("Alice", "5"));
+    sessionManager.registerEstimate(sessionId, new Estimate("ALICE", "8"));
+
+    List<Estimate> results = sessionManager.getResults(sessionId);
+    assertEquals(1, results.size());
+    assertEquals(new Estimate("ALICE", "8"), results.get(0));
+  }
+
+  /** Upsert for one user must not affect estimates from other users in the same session. */
+  @Test
+  void testRegisterEstimateDoesNotAffectOtherUsers() {
+    final String sessionId = sessionManager.createSession();
+    sessionManager.registerEstimate(sessionId, new Estimate("Alice", "5"));
+    sessionManager.registerEstimate(sessionId, new Estimate("Bob", "3"));
+    sessionManager.registerEstimate(sessionId, new Estimate("Alice", "8"));
+
+    List<Estimate> results = sessionManager.getResults(sessionId);
+    assertEquals(2, results.size());
+    assertTrue(results.contains(new Estimate("Alice", "8")));
+    assertTrue(results.contains(new Estimate("Bob", "3")));
+  }
+
   @Test
   void testGetResultsReturnsDefensiveCopy() {
     final String sessionId = sessionManager.createSession();


### PR DESCRIPTION
## Summary

Closes #111. Re-voting in the same round previously no-op'd at the controller layer, so the second click was silently dropped — the frontend's optimistic update would then visibly revert when the broadcast echoed the unchanged state.

This PR makes the standard planning-poker behaviour the default: members can change their card freely until the round is reset. A separate host-controlled lock-on-submit toggle is tracked under #109.

Surfaced by the TLA+ slice at `specs/VotingAndReset.tla` (action `UpdateVote(m, v)`).

## Upsert strategy

Pushed the dedup down into `SessionManager.registerEstimate` itself rather than introducing a parallel `replaceEstimate` API or branching at the controller. Reasons:

- Single write path for estimates — every caller (controllers, future code, tests) gets upsert semantics for free; no risk of a caller forgetting to dedup.
- Matches the case-insensitive convention already used by `SessionManager.removeUser`.
- Compound op (`removeIf` + `put`) is wrapped in `synchronized (sessionEstimates)` so concurrent callers cannot observe a transient state with both old and new values, nor with neither — the documented atomicity contract for `Multimaps.synchronizedListMultimap`.
- `VoteController` becomes simpler: drop the `!containsUserEstimate` guard and unconditionally call `registerEstimate`.

## Tests

- `SessionManagerTest`: three new cases covering replace-on-second-call, case-insensitive match, and isolation from other users' estimates.
- `VoteControllerTest`: `testReVoteReplacesExistingEstimate` replaces the old `testVoteUserAlreadyVoted` (which asserted the buggy silent-drop behaviour). `testVote` is updated for the simpler call sequence.
- `VotingAndResetSpecRegressionTest.testReVoteReplacesOriginalValue` is re-enabled (the `@Disabled` placeholder from #112 is removed). Both spec regression tests now pass on this branch.

## Stacked on #112

This PR is stacked on `fix/110-reset-host-only` (PR #112). Base is intentionally that branch, not `master`, so the diff under review here is just the re-vote fix. When #112 merges, GitHub will auto-rebase this PR onto `master` — no manual rebase required.

## Test plan

- [x] `./gradlew planningpoker-api:test` — all backend tests green
- [x] `./gradlew spotlessCheck` — green
- [x] Targeted run: `VoteControllerTest`, `SessionManagerTest.testRegisterEstimate*`, `VotingAndResetSpecRegressionTest` — all pass
- [ ] CI to confirm lint + unit + e2e green

🤖 Generated with [Claude Code](https://claude.com/claude-code)