### PR TITLE
chore(web): remove dead setConsensusOverride action / constant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Two-module Gradle project: `planningpoker-web` (React 18 frontend) and `planning
 
 - **React 18** with functional components and hooks
 - **MUI v5** with custom dark/light theme (toggle in header)
-- **Redux 4** + react-redux 8 (`useSelector`/`useDispatch`)
+- **Redux 5** + `@reduxjs/toolkit` 2.x + react-redux 8 (`useSelector`/`useDispatch`)
 - **react-router-dom v6** (`Routes`, `useNavigate`)
 - **chart.js 4** + react-chartjs-2 v5 for results bar chart
 - **@stomp/stompjs** via custom `useStomp` hook for WebSocket
@@ -131,9 +131,9 @@ A real-time planning poker web app for distributed teams. Hosts pick an estimati
 - Spring Boot 3.4.4 - Backend application framework (`planningpoker-api/`)
 - MUI v5 (`@mui/material` ^5.15.0) - Component library with custom theme
 - `@emotion/react` ^11.11.0 and `@emotion/styled` ^11.11.0 - CSS-in-JS (required by MUI)
-- Redux 4.2.1 - Global state store (`planningpoker-web/src/reducers/`)
+- Redux 5.0.1 + `@reduxjs/toolkit` 2.11.2 - Global state store wired via `configureStore` in `planningpoker-web/src/App.jsx`
 - react-redux 8.1.0 - React bindings (`useSelector`/`useDispatch`)
-- redux-promise 0.6.0 - Middleware for async action payloads
+- Async actions are plain thunks (RTK's default middleware includes `redux-thunk`); no extra promise middleware
 - react-router-dom 6.20 - Client-side routing (`planningpoker-web/src/App.jsx`)
 - chart.js 4.4 + react-chartjs-2 5.2 - Results bar chart (`planningpoker-web/src/containers/ResultsChart.jsx`)
 - `@stomp/stompjs` 7.0 - STOMP over WebSocket client
@@ -216,9 +216,9 @@ A real-time planning poker web app for distributed teams. Hosts pick an estimati
 - Component variants: `variant="contained"` for primary, `variant="outlined"` for secondary buttons
 - Theme customization centralized in `src/theme.js` — shared config object spread into dark/light variants
 ## Redux Patterns
-- All actions: `{ type, payload, meta }` — redux-promise middleware resolves promise payloads
-- Event actions (no async): `{ type }` only (e.g., `gameCreated()`, `userRegistered()`)
-- Async actions: payload is an axios Promise; `meta` carries local data not in the response
+- Store wired via `configureStore` from `@reduxjs/toolkit` (RTK includes `redux-thunk` by default)
+- Event actions: `{ type, payload?, meta? }` plain object creators (e.g., `gameCreated()`, `userRegistered()`)
+- Async actions: thunks — `(args) => async (dispatch) => { try { dispatch(...success) } catch { dispatch(...error: true) } }`. No `createAsyncThunk` yet; the existing `error: true` flag pattern is the convention
 ## Error Handling
 - Frontend: action creators `.catch()` errors and dispatch `showError(msg)` (`err.response?.data?.error || 'Fallback message'`); non-critical failures use `console.error`; no global error boundary
 - Backend: `ErrorHandler` (`@ControllerAdvice`) maps `IllegalArgumentException` → 400, `HostActionException` → 403, all others → 500; controllers let exceptions propagate

--- a/planningpoker-web/src/actions/index.js
+++ b/planningpoker-web/src/actions/index.js
@@ -21,7 +21,6 @@ export const SET_LABEL = 'set-label'
 export const LABEL_UPDATED = 'label-updated'
 export const ROUND_COMPLETED = 'round-completed'
 export const ROUNDS_REPLACE = 'rounds-replace'
-export const SET_CONSENSUS_OVERRIDE = 'set-consensus-override'
 
 export const showError = (message) => ({ type: 'show-error', payload: message })
 export const clearError = () => ({ type: 'clear-error' })
@@ -58,8 +57,6 @@ export const labelUpdated = (label) => ({ type: LABEL_UPDATED, payload: label })
 export const roundCompleted = (round) => ({ type: ROUND_COMPLETED, payload: round })
 
 export const roundsReplace = (rounds) => ({ type: ROUNDS_REPLACE, payload: rounds })
-
-export const setConsensusOverride = (value) => ({ type: SET_CONSENSUS_OVERRIDE, payload: value })
 
 export const usersUpdated = (users) => ({ type: USERS_UPDATED, payload: users })
 


### PR DESCRIPTION
Closes #119.

The `SET_CONSENSUS_OVERRIDE` action type and `setConsensusOverride` action creator in `actions/index.js` were exported but never dispatched anywhere. The consensus-override feature is implemented via local `useState` in `GamePane.jsx` (and passed down as a prop to `Results.jsx`); the Redux action was a leftover from an earlier design.

Verified via `grep` that no other code imports either symbol.

## Test plan

- [x] Frontend unit tests pass (158/158)
- [x] No imports break (grep clean)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)