### PR TITLE
fix(api): close concurrency lock-scope gaps in joinSession, removeUser, vote

### DIFF
--- a/planningpoker-api/src/main/java/com/richashworth/planningpoker/controller/GameController.java
+++ b/planningpoker-api/src/main/java/com/richashworth/planningpoker/controller/GameController.java
@@ -55,6 +55,13 @@ public class GameController {
       @RequestParam(name = "sessionId") final String sessionId,
       @RequestParam(name = "userName") final String userName) {
     validateUserName(userName);
+    final SchemeConfig config;
+    final List<String> values;
+    final String host;
+    final int round;
+    final List<Estimate> results;
+    final String label;
+    final List<Round> completedRounds;
     synchronized (sessionManager) {
       if (!sessionManager.isSessionActive(sessionId)) {
         throw new IllegalArgumentException("session not found");
@@ -65,15 +72,15 @@ public class GameController {
         logger.info(
             "user {} joined session {}", LogSafeIds.hash(userName), LogSafeIds.hash(sessionId));
       }
+      config = sessionManager.getSessionSchemeConfig(sessionId);
+      values = sessionManager.getSessionLegalValues(sessionId);
+      host = sessionManager.getHost(sessionId);
+      round = sessionManager.getRound(sessionId);
+      results = sessionManager.getResults(sessionId);
+      label = sessionManager.getLabel(sessionId);
+      completedRounds = sessionManager.getCompletedRounds(sessionId);
     }
     messagingUtils.sendUsersMessage(sessionId);
-    SchemeConfig config = sessionManager.getSessionSchemeConfig(sessionId);
-    List<String> values = sessionManager.getSessionLegalValues(sessionId);
-    String host = sessionManager.getHost(sessionId);
-    int round = sessionManager.getRound(sessionId);
-    List<Estimate> results = sessionManager.getResults(sessionId);
-    String label = sessionManager.getLabel(sessionId);
-    List<Round> completedRounds = sessionManager.getCompletedRounds(sessionId);
     return new SessionResponse(
         host,
         null,

--- a/planningpoker-api/src/main/java/com/richashworth/planningpoker/controller/VoteController.java
+++ b/planningpoker-api/src/main/java/com/richashworth/planningpoker/controller/VoteController.java
@@ -40,15 +40,14 @@ public class VoteController {
       @RequestParam(name = "sessionId") final String sessionId,
       @RequestParam(name = "userName") final String userName,
       @RequestParam(name = "estimateValue") final String estimateValue) {
-    List<String> legalValues = sessionManager.getSessionLegalValues(sessionId);
-    if (!legalValues.contains(estimateValue)) {
-      throw new IllegalArgumentException("Invalid estimate value");
-    }
     int round;
     List<Estimate> results;
     synchronized (sessionManager) {
       if (!sessionManager.isSessionActive(sessionId)) {
         throw new IllegalArgumentException("Session not active");
+      }
+      if (!sessionManager.getSessionLegalValues(sessionId).contains(estimateValue)) {
+        throw new IllegalArgumentException("Invalid estimate value");
       }
       if (!CollectionUtils.containsIgnoreCase(
           sessionManager.getSessionUsers(sessionId), userName)) {

--- a/planningpoker-api/src/main/java/com/richashworth/planningpoker/service/SessionManager.java
+++ b/planningpoker-api/src/main/java/com/richashworth/planningpoker/service/SessionManager.java
@@ -183,11 +183,20 @@ public class SessionManager {
 
   public synchronized void removeUser(String userName, String sessionId) {
     sessionUsers.get(sessionId).removeIf(u -> u.equalsIgnoreCase(userName));
-    sessionEstimates
-        .entries()
-        .removeIf(
-            e ->
-                e.getKey().equals(sessionId) && e.getValue().userName().equalsIgnoreCase(userName));
+    // Match registerEstimate's locking discipline: iteration on a
+    // Multimaps.synchronizedListMultimap
+    // requires holding the multimap's own monitor. Without this, a concurrent registerEstimate
+    // (which
+    // holds only sessionEstimates) can mutate the map mid-iteration, throwing CME or producing a
+    // partial removal.
+    synchronized (sessionEstimates) {
+      sessionEstimates
+          .entries()
+          .removeIf(
+              e ->
+                  e.getKey().equals(sessionId)
+                      && e.getValue().userName().equalsIgnoreCase(userName));
+    }
     String currentHost = sessionHosts.get(sessionId);
     if (currentHost != null && currentHost.equalsIgnoreCase(userName)) {
       List<String> remainingUsers = sessionUsers.get(sessionId);

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/VoteControllerTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/VoteControllerTest.java
@@ -22,8 +22,8 @@ class VoteControllerTest extends AbstractControllerTest {
 
   @Test
   void testVote() {
-    when(sessionManager.getSessionLegalValues(SESSION_ID)).thenReturn(STORY_POINT_VALUES);
     when(sessionManager.isSessionActive(SESSION_ID)).thenReturn(true);
+    when(sessionManager.getSessionLegalValues(SESSION_ID)).thenReturn(STORY_POINT_VALUES);
     when(sessionManager.getSessionUsers(SESSION_ID)).thenReturn(Lists.newArrayList(USER_NAME));
     when(sessionManager.getRound(SESSION_ID)).thenReturn(2);
     List<Estimate> afterVote = List.of(ESTIMATE);
@@ -31,8 +31,8 @@ class VoteControllerTest extends AbstractControllerTest {
     VoteResponse response = voteController.vote(SESSION_ID, USER_NAME, ESTIMATE_VALUE);
     assertEquals(2, response.round());
     assertEquals(afterVote, response.results());
-    inOrder.verify(sessionManager, times(1)).getSessionLegalValues(SESSION_ID);
     inOrder.verify(sessionManager, times(1)).isSessionActive(SESSION_ID);
+    inOrder.verify(sessionManager, times(1)).getSessionLegalValues(SESSION_ID);
     inOrder.verify(sessionManager, times(1)).getSessionUsers(SESSION_ID);
     inOrder.verify(sessionManager, times(1)).registerEstimate(SESSION_ID, ESTIMATE);
     inOrder.verify(sessionManager, times(1)).getRound(SESSION_ID);
@@ -50,8 +50,8 @@ class VoteControllerTest extends AbstractControllerTest {
   void testReVoteReplacesExistingEstimate() {
     String newValue = "8";
     Estimate newEstimate = new Estimate(USER_NAME, newValue);
-    when(sessionManager.getSessionLegalValues(SESSION_ID)).thenReturn(STORY_POINT_VALUES);
     when(sessionManager.isSessionActive(SESSION_ID)).thenReturn(true);
+    when(sessionManager.getSessionLegalValues(SESSION_ID)).thenReturn(STORY_POINT_VALUES);
     when(sessionManager.getSessionUsers(SESSION_ID)).thenReturn(Lists.newArrayList(USER_NAME));
     when(sessionManager.getRound(SESSION_ID)).thenReturn(1);
     // Source-of-truth post-upsert results: the new estimate has replaced the old one.
@@ -61,8 +61,8 @@ class VoteControllerTest extends AbstractControllerTest {
 
     assertEquals(1, response.round());
     assertEquals(List.of(newEstimate), response.results());
-    inOrder.verify(sessionManager, times(1)).getSessionLegalValues(SESSION_ID);
     inOrder.verify(sessionManager, times(1)).isSessionActive(SESSION_ID);
+    inOrder.verify(sessionManager, times(1)).getSessionLegalValues(SESSION_ID);
     inOrder.verify(sessionManager, times(1)).getSessionUsers(SESSION_ID);
     // Crucial: registerEstimate is invoked even though a prior estimate exists for this user.
     inOrder.verify(sessionManager, times(1)).registerEstimate(SESSION_ID, newEstimate);
@@ -74,7 +74,6 @@ class VoteControllerTest extends AbstractControllerTest {
 
   @Test
   void testVoteInvalidSession() {
-    when(sessionManager.getSessionLegalValues(SESSION_ID)).thenReturn(STORY_POINT_VALUES);
     when(sessionManager.isSessionActive(SESSION_ID)).thenReturn(false);
     assertThrows(
         IllegalArgumentException.class,
@@ -83,8 +82,8 @@ class VoteControllerTest extends AbstractControllerTest {
 
   @Test
   void testVoteNonMemberRejected() {
-    when(sessionManager.getSessionLegalValues(SESSION_ID)).thenReturn(STORY_POINT_VALUES);
     when(sessionManager.isSessionActive(SESSION_ID)).thenReturn(true);
+    when(sessionManager.getSessionLegalValues(SESSION_ID)).thenReturn(STORY_POINT_VALUES);
     when(sessionManager.getSessionUsers(SESSION_ID)).thenReturn(Lists.newArrayList());
     assertThrows(
         IllegalArgumentException.class,
@@ -93,6 +92,7 @@ class VoteControllerTest extends AbstractControllerTest {
 
   @Test
   void testVoteInvalidEstimateRejected() {
+    when(sessionManager.isSessionActive(SESSION_ID)).thenReturn(true);
     when(sessionManager.getSessionLegalValues(SESSION_ID)).thenReturn(STORY_POINT_VALUES);
     assertThrows(
         IllegalArgumentException.class, () -> voteController.vote(SESSION_ID, USER_NAME, "999"));

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/VotingAndResetConcurrencyTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/VotingAndResetConcurrencyTest.java
@@ -1,6 +1,7 @@
 package com.richashworth.planningpoker.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -252,6 +253,86 @@ class VotingAndResetConcurrencyTest {
       assertTrue(
           seen.add(e.userName()),
           "TypeOK: at most one vote per member per round; duplicate for " + e.userName());
+    }
+  }
+
+  /**
+   * Spec property: {@code UpdateVote} and {@code Leave} are atomic — both mutate {@code
+   * serverVotes} as a single indivisible step. The Java implementation must therefore serialise the
+   * two SessionManager methods on the same monitor. {@code registerEstimate} synchronises on {@code
+   * sessionEstimates}; {@code removeUser} must do the same when it iterates {@code entries()},
+   * otherwise the multimap's iterator races with {@code put} and throws CME.
+   *
+   * <p>This test exercises {@link SessionManager} directly (not through controllers) because the
+   * controller layer wraps both methods in {@code synchronized(sessionManager)}, which masks the
+   * underlying API-level race. The SessionManager API must be safe on its own — scheduled tasks and
+   * future callers will not always go through a controller.
+   */
+  @Test
+  void testConcurrentRegisterEstimateAndRemoveUserMaintainsInvariants()
+      throws InterruptedException {
+    String sessionId = sessionManager.createSession();
+    int memberCount = 60;
+    List<String> voters = new ArrayList<>();
+    List<String> leavers = new ArrayList<>();
+    String legal = sessionManager.getSessionLegalValues(sessionId).get(0);
+
+    for (int i = 0; i < memberCount; i++) {
+      String name = "M" + i;
+      sessionManager.registerUser(name, sessionId);
+      sessionManager.registerEstimate(sessionId, new Estimate(name, legal));
+      if (i < memberCount / 2) {
+        voters.add(name);
+      } else {
+        leavers.add(name);
+      }
+    }
+
+    CountDownLatch start = new CountDownLatch(1);
+    ExecutorService pool = Executors.newFixedThreadPool(memberCount);
+    List<Throwable> errors = Collections.synchronizedList(new ArrayList<>());
+    int iterations = 100;
+
+    for (String v : voters) {
+      pool.submit(
+          () -> {
+            try {
+              start.await();
+              for (int n = 0; n < iterations; n++) {
+                sessionManager.registerEstimate(sessionId, new Estimate(v, legal));
+              }
+            } catch (Throwable t) {
+              errors.add(t);
+            }
+          });
+    }
+    for (String l : leavers) {
+      pool.submit(
+          () -> {
+            try {
+              start.await();
+              for (int n = 0; n < iterations; n++) {
+                sessionManager.removeUser(l, sessionId);
+              }
+            } catch (Throwable t) {
+              errors.add(t);
+            }
+          });
+    }
+
+    start.countDown();
+    pool.shutdown();
+    assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS));
+    assertTrue(
+        errors.isEmpty(),
+        "registerEstimate + removeUser must not race the multimap iteration: " + errors);
+
+    // No leaver should have a lingering estimate
+    Set<String> leaverSet = new HashSet<>(leavers);
+    for (Estimate e : sessionManager.getResults(sessionId)) {
+      assertFalse(
+          leaverSet.contains(e.userName()),
+          "leaver " + e.userName() + " has lingering estimate (race left stale state)");
     }
   }
 


### PR DESCRIPTION
Closes #115.

## Summary

Three backend lock-discipline issues identified in the audit. Each is a place where the Java implementation drifts from the atomicity the TLA+ spec at `specs/VotingAndReset.tla` assumes:

1. **`GameController.joinSession`** read 7 fields of session state *after* the `synchronized(sessionManager)` block closed → response could be internally inconsistent if a concurrent reset/eviction landed in the gap. Fix: pull the reads inside the block.

2. **`SessionManager.removeUser`** held `this`-monitor but iterated `sessionEstimates.entries()` without holding the multimap's monitor — `registerEstimate` uses `synchronized(sessionEstimates)`. Different locks → no mutual exclusion → CME-on-iterator under concurrent calls. The controller layer's `synchronized(sessionManager)` wrap masks the bug today, but the SessionManager API itself was not safe for direct callers (scheduled tasks, future services). Fix: wrap the iteration in `synchronized(sessionEstimates)`.

3. **`VoteController.vote`** fetched `getSessionLegalValues` outside the synchronized block. Mostly benign (a concurrent eviction would throw on the later `isSessionActive` check) but inconsistent. Fix: move the fetch inside the block.

## Why TLA+ didn't catch these

The spec models actions like `UpdateVote(m, v)` and `Leave` as *atomic transitions*. It proves the protocol is safe given that atomicity. These bugs are about whether the Java implementation actually delivers it — which is below the spec's level of abstraction.

## Tests

- New regression `testConcurrentRegisterEstimateAndRemoveUserMaintainsInvariants` in `VotingAndResetConcurrencyTest`. Drives SessionManager directly (since the controller wrapping masks the bug), 60 members × 100 iterations, ~64ms in CI. Without the lock fix this throws CME; with the fix the final state has no stale leaver estimates.
- `VoteControllerTest` updated for the new `isSessionActive → getSessionLegalValues` call order.

## Test plan

- [x] All 143 backend unit tests pass locally
- [x] New concurrency test runs in <100ms
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)