### PR TITLE
fix(web): guard Create/Join forms against double-submit

### DIFF
--- a/planningpoker-web/src/pages/CreateGame.jsx
+++ b/planningpoker-web/src/pages/CreateGame.jsx
@@ -63,25 +63,29 @@ export default function CreateGame() {
 
   const handleSubmit = async (e) => {
     e.preventDefault()
+    if (submitting) return
     const nameRegex = /^[a-zA-Z0-9 _-]{3,20}$/
     if (!nameRegex.test(playerName)) return
     if (!isCustomValid()) return
     setSubmitting(true)
-    await dispatch(
-      createGame(
-        playerName,
-        {
-          schemeType,
-          customValues: schemeType === 'custom' ? customValues : null,
-          includeUnsure,
-        },
-        () => {
-          dispatch(gameCreated())
-          navigate('/game')
-        },
-      ),
-    )
-    setSubmitting(false)
+    try {
+      await dispatch(
+        createGame(
+          playerName,
+          {
+            schemeType,
+            customValues: schemeType === 'custom' ? customValues : null,
+            includeUnsure,
+          },
+          () => {
+            dispatch(gameCreated())
+            navigate('/game')
+          },
+        ),
+      )
+    } finally {
+      setSubmitting(false)
+    }
   }
 
   return (

--- a/planningpoker-web/src/pages/JoinGame.jsx
+++ b/planningpoker-web/src/pages/JoinGame.jsx
@@ -20,16 +20,20 @@ export default function JoinGame() {
 
   const handleSubmit = async (e) => {
     e.preventDefault()
+    if (submitting) return
     const nameRegex = /^[a-zA-Z0-9 _-]{3,20}$/
     if (!nameRegex.test(playerName)) return
     setSubmitting(true)
-    await dispatch(
-      joinGame(playerName, sessionId, () => {
-        dispatch(userRegistered())
-        navigate('/game')
-      }),
-    )
-    setSubmitting(false)
+    try {
+      await dispatch(
+        joinGame(playerName, sessionId, () => {
+          dispatch(userRegistered())
+          navigate('/game')
+        }),
+      )
+    } finally {
+      setSubmitting(false)
+    }
   }
 
   return (

--- a/planningpoker-web/src/pages/__tests__/CreateGame.test.jsx
+++ b/planningpoker-web/src/pages/__tests__/CreateGame.test.jsx
@@ -71,4 +71,91 @@ describe('CreateGame page', () => {
       expect.anything(),
     )
   })
+
+  it('disables the submit button while the POST is in flight and re-enables on success', async () => {
+    let resolvePost
+    axios.post.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolvePost = () => resolve({ data: { sessionId: 'abc12345' } })
+        }),
+    )
+
+    renderPage()
+    fireEvent.change(screen.getByLabelText(/Your Name/i), { target: { value: 'alice' } })
+
+    const button = screen.getByRole('button', { name: /Start Game/ })
+    expect(button).not.toBeDisabled()
+
+    const form = button.closest('form')
+    await act(async () => {
+      fireEvent.submit(form)
+    })
+
+    // While the in-flight POST is unresolved, the button must stay disabled
+    // so a second click can't fire another /createSession.
+    expect(button).toBeDisabled()
+
+    await act(async () => {
+      resolvePost()
+    })
+
+    expect(button).not.toBeDisabled()
+    expect(axios.post).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-enables the submit button after a failed POST', async () => {
+    let rejectPost
+    axios.post.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectPost = () => reject(new Error('boom'))
+        }),
+    )
+
+    renderPage()
+    fireEvent.change(screen.getByLabelText(/Your Name/i), { target: { value: 'alice' } })
+
+    const button = screen.getByRole('button', { name: /Start Game/ })
+    const form = button.closest('form')
+    await act(async () => {
+      fireEvent.submit(form)
+    })
+    expect(button).toBeDisabled()
+
+    await act(async () => {
+      rejectPost()
+    })
+
+    expect(button).not.toBeDisabled()
+  })
+
+  it('does not issue a second POST when the form is re-submitted while submitting', async () => {
+    let resolvePost
+    axios.post.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolvePost = () => resolve({ data: { sessionId: 'abc12345' } })
+        }),
+    )
+
+    renderPage()
+    fireEvent.change(screen.getByLabelText(/Your Name/i), { target: { value: 'alice' } })
+
+    const form = screen.getByRole('button', { name: /Start Game/ }).closest('form')
+    await act(async () => {
+      fireEvent.submit(form)
+    })
+
+    // Simulate a rapid second submission while the first is still pending.
+    await act(async () => {
+      fireEvent.submit(form)
+    })
+
+    expect(axios.post).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolvePost()
+    })
+  })
 })

--- a/planningpoker-web/src/pages/__tests__/JoinGame.test.jsx
+++ b/planningpoker-web/src/pages/__tests__/JoinGame.test.jsx
@@ -71,4 +71,94 @@ describe('JoinGame page', () => {
       expect.anything(),
     )
   })
+
+  it('disables the submit button while the POST is in flight and re-enables on success', async () => {
+    let resolvePost
+    axios.post.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolvePost = () => resolve({ data: { sessionId: 'abc12345' } })
+        }),
+    )
+
+    renderPage()
+    fireEvent.change(screen.getByLabelText(/Your Name/i), { target: { value: 'alice' } })
+    fireEvent.change(screen.getByLabelText(/Session ID/), { target: { value: 'abc12345' } })
+
+    const button = screen.getByRole('button', { name: /Join Game/ })
+    expect(button).not.toBeDisabled()
+
+    const form = button.closest('form')
+    await act(async () => {
+      fireEvent.submit(form)
+    })
+
+    // While the in-flight POST is unresolved, the button must stay disabled
+    // so a second click can't fire another /joinSession.
+    expect(button).toBeDisabled()
+
+    await act(async () => {
+      resolvePost()
+    })
+
+    expect(button).not.toBeDisabled()
+    expect(axios.post).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-enables the submit button after a failed POST', async () => {
+    let rejectPost
+    axios.post.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectPost = () => reject(new Error('boom'))
+        }),
+    )
+
+    renderPage()
+    fireEvent.change(screen.getByLabelText(/Your Name/i), { target: { value: 'alice' } })
+    fireEvent.change(screen.getByLabelText(/Session ID/), { target: { value: 'abc12345' } })
+
+    const button = screen.getByRole('button', { name: /Join Game/ })
+    const form = button.closest('form')
+    await act(async () => {
+      fireEvent.submit(form)
+    })
+    expect(button).toBeDisabled()
+
+    await act(async () => {
+      rejectPost()
+    })
+
+    expect(button).not.toBeDisabled()
+  })
+
+  it('does not issue a second POST when the form is re-submitted while submitting', async () => {
+    let resolvePost
+    axios.post.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolvePost = () => resolve({ data: { sessionId: 'abc12345' } })
+        }),
+    )
+
+    renderPage()
+    fireEvent.change(screen.getByLabelText(/Your Name/i), { target: { value: 'alice' } })
+    fireEvent.change(screen.getByLabelText(/Session ID/), { target: { value: 'abc12345' } })
+
+    const form = screen.getByRole('button', { name: /Join Game/ }).closest('form')
+    await act(async () => {
+      fireEvent.submit(form)
+    })
+
+    // Simulate a rapid second submission while the first is still pending.
+    await act(async () => {
+      fireEvent.submit(form)
+    })
+
+    expect(axios.post).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolvePost()
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- Wraps the Create/Join `dispatch` in `try/finally` so the local `submitting` flag is reliably reset on success **and** error, and short-circuits re-entry when `submitting` is already true. Defends against (a) a future thunk change that throws synchronously, and (b) a rapid second `submit` event slipping through before React commits the disabled state.
- The companion optimistic-vote revert in `reducer_results` already removes the optimistic entry on `VOTE` with `action.error === true` (commit b5d164a). Per the issue split with #116, the reducer-level regression test ships with the #116 PR — intentionally not added here so the coupling between the two PRs is visible.

## Test plan
- [x] `cd planningpoker-web && npx vitest run --run` — 164 / 164 pass locally (23 files), including 6 new component tests across `CreateGame.test.jsx` and `JoinGame.test.jsx` covering: button disabled while in-flight, re-enable on resolve, re-enable on reject, no second POST on rapid resubmit.
- [ ] CI Playwright e2e suite (skipped locally — would conflict with parallel teammate worktree).

Closes #117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)