### PR TITLE
chore(ci): add concurrency groups to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,6 +2,10 @@ name: Dependabot auto-merge
 
 on: pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
## Summary
- Cancels in-progress CI runs on PR branches when new commits land (saves runner time on rapid pushes).
- Adds the same concurrency group to the dependabot auto-merge workflow so overlapping runs on the same PR can't race.
- Master pushes are NOT cancelled, only serialized — semantic-release won't overlap with itself.

## Test plan
- [ ] Push two quick commits to this PR; confirm the older CI run cancels and only the latest completes.
- [ ] Confirm a master push after merge runs CI and semantic-release once, end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)