### PR TITLE
feat(web): restack results layout; cap votes panel with sticky-header scroll

### DIFF
--- a/planningpoker-web/src/containers/GamePane.jsx
+++ b/planningpoker-web/src/containers/GamePane.jsx
@@ -96,9 +96,11 @@ export default function GamePane({ connected }) {
             setConsensusOverride={setConsensusOverride}
           />
         ) : (
-          <Vote />
+          <>
+            <Vote />
+            <SessionHistory consensusOverride={consensusOverride} />
+          </>
         )}
-        <SessionHistory consensusOverride={consensusOverride} />
       </Box>
     </>
   )

--- a/planningpoker-web/src/containers/Results.jsx
+++ b/planningpoker-web/src/containers/Results.jsx
@@ -4,6 +4,7 @@ import Typography from '@mui/material/Typography'
 import Button from '@mui/material/Button'
 import ResultsTable from './ResultsTable'
 import ResultsChart from './ResultsChart'
+import SessionHistory from './SessionHistory'
 import ConsensusCardRail from '../components/ConsensusCardRail'
 import { resetSession } from '../actions'
 import { calcConsensus } from '../utils/consensus'
@@ -87,17 +88,20 @@ export default function Results({ consensusOverride, setConsensusOverride }) {
           minHeight: 300,
         }}
       >
-        <Box
-          sx={{
-            bgcolor: 'background.paper',
-            border: '1px solid',
-            borderColor: 'divider',
-            borderRadius: 1,
-            p: 2.5,
-            transition: 'border-color 0.3s ease, background-color 0.3s ease',
-          }}
-        >
-          <ResultsChart />
+        <Box sx={{ minWidth: 0 }}>
+          <Box
+            sx={{
+              bgcolor: 'background.paper',
+              border: '1px solid',
+              borderColor: 'divider',
+              borderRadius: 1,
+              p: 2.5,
+              transition: 'border-color 0.3s ease, background-color 0.3s ease',
+            }}
+          >
+            <ResultsChart />
+          </Box>
+          <SessionHistory consensusOverride={consensusOverride} />
         </Box>
         <ResultsTable />
       </Box>

--- a/planningpoker-web/src/containers/ResultsTable.jsx
+++ b/planningpoker-web/src/containers/ResultsTable.jsx
@@ -46,83 +46,102 @@ export default function ResultsTable() {
       >
         Votes
       </Typography>
-      <Box
-        component="table"
-        aria-label="Voting results"
-        sx={{ width: '100%', borderCollapse: 'collapse' }}
-      >
-        <thead>
-          <tr>
-            <Box
-              component="th"
-              scope="col"
-              sx={{
-                textAlign: 'left',
-                pb: 0.75,
-                fontSize: '0.65rem',
-                color: 'text.disabled',
-                fontWeight: 600,
-                textTransform: 'uppercase',
-                letterSpacing: '0.05em',
-              }}
-            >
-              Player
-            </Box>
-            <Box
-              component="th"
-              scope="col"
-              sx={{
-                textAlign: 'right',
-                pb: 0.75,
-                fontSize: '0.65rem',
-                color: 'text.disabled',
-                fontWeight: 600,
-                textTransform: 'uppercase',
-                letterSpacing: '0.05em',
-              }}
-            >
-              Vote
-            </Box>
-          </tr>
-        </thead>
-        <tbody>
-          {sortedResults.map((x) => (
-            <tr key={x.userName}>
-              <Box component="td" sx={{ py: 0.5, fontSize: '0.85rem', color: 'text.primary' }}>
-                {startCase(x.userName)}
-              </Box>
+      <Box sx={{ maxHeight: 360, overflowY: 'auto' }}>
+        <Box
+          component="table"
+          aria-label="Voting results"
+          sx={{ width: '100%', borderCollapse: 'collapse' }}
+        >
+          <thead>
+            <tr>
               <Box
-                component="td"
+                component="th"
+                scope="col"
                 sx={{
-                  py: 0.5,
-                  fontSize: '0.85rem',
-                  color: 'text.primary',
-                  textAlign: 'right',
-                  fontWeight: 700,
-                  fontVariantNumeric: 'tabular-nums',
+                  textAlign: 'left',
+                  pb: 0.75,
+                  fontSize: '0.65rem',
+                  color: 'text.disabled',
+                  fontWeight: 600,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.05em',
+                  position: 'sticky',
+                  top: 0,
+                  bgcolor: 'background.paper',
+                  zIndex: 1,
+                  borderBottom: '1px solid',
+                  borderColor: 'divider',
                 }}
               >
-                {x.estimateValue}
-              </Box>
-            </tr>
-          ))}
-          {notVoted.map((x) => (
-            <tr key={x}>
-              <Box
-                component="td"
-                sx={{ py: 0.5, fontSize: '0.85rem', color: 'text.disabled', fontStyle: 'italic' }}
-              >
-                {startCase(x)}
+                Player
               </Box>
               <Box
-                component="td"
-                sx={{ py: 0.5, fontSize: '0.85rem', color: 'text.disabled', textAlign: 'right' }}
+                component="th"
+                scope="col"
+                sx={{
+                  textAlign: 'right',
+                  pb: 0.75,
+                  fontSize: '0.65rem',
+                  color: 'text.disabled',
+                  fontWeight: 600,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.05em',
+                  position: 'sticky',
+                  top: 0,
+                  bgcolor: 'background.paper',
+                  zIndex: 1,
+                  borderBottom: '1px solid',
+                  borderColor: 'divider',
+                }}
               >
-                —
+                Vote
               </Box>
             </tr>
-          ))}
-        </tbody>
+          </thead>
+          <tbody>
+            {sortedResults.map((x) => (
+              <tr key={x.userName}>
+                <Box component="td" sx={{ py: 0.5, fontSize: '0.85rem', color: 'text.primary' }}>
+                  {startCase(x.userName)}
+                </Box>
+                <Box
+                  component="td"
+                  sx={{
+                    py: 0.5,
+                    fontSize: '0.85rem',
+                    color: 'text.primary',
+                    textAlign: 'right',
+                    fontWeight: 700,
+                    fontVariantNumeric: 'tabular-nums',
+                  }}
+                >
+                  {x.estimateValue}
+                </Box>
+              </tr>
+            ))}
+            {notVoted.map((x) => (
+              <tr key={x}>
+                <Box
+                  component="td"
+                  sx={{
+                    py: 0.5,
+                    fontSize: '0.85rem',
+                    color: 'text.disabled',
+                    fontStyle: 'italic',
+                  }}
+                >
+                  {startCase(x)}
+                </Box>
+                <Box
+                  component="td"
+                  sx={{ py: 0.5, fontSize: '0.85rem', color: 'text.disabled', textAlign: 'right' }}
+                >
+                  —
+                </Box>
+              </tr>
+            ))}
+          </tbody>
+        </Box>
       </Box>
     </Box>
   )


### PR DESCRIPTION
## Summary
- On the Results screen, `SessionHistory` now sits in the left grid column under the chart so the right rail (votes table) can extend taller without being broken by a full-width history banner below.
- Voting phase is unchanged: `SessionHistory` still renders full-width below `<Vote />`. `GamePane` now only emits it on the voting branch — the Results path renders its own copy internally.
- Votes panel is capped at `maxHeight: 360` with `overflowY: 'auto'`. Only the table rows scroll — the panel border, padding, and "Votes" overline stay fixed. Table `<th>` cells are `position: sticky; top: 0` with a divider so the header stays visible during scroll. Grid widths (`1fr 240px`) unchanged.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npx vitest run` — 176/176 passing (23 files)
- [ ] Manual: with 15+ voters, votes panel scrolls inside while sticky header remains pinned
- [ ] Manual: voting phase still shows session history full-width under Vote
- [ ] Manual: results phase shows chart + history stacked left, votes table right
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)