### PR TITLE
Revert direct-to-master comment cleanup pending CI verification

### DIFF
--- a/planningpoker-api/src/main/java/com/richashworth/planningpoker/controller/VoteController.java
+++ b/planningpoker-api/src/main/java/com/richashworth/planningpoker/controller/VoteController.java
@@ -58,6 +58,8 @@ public class VoteController {
           LogSafeIds.hash(userName),
           LogSafeIds.hash(sessionId),
           LogSafeIds.hash(estimateValue));
+      // registerEstimate is an upsert: it replaces any prior estimate this user already cast in
+      // the current round. See SessionManager#registerEstimate.
       sessionManager.registerEstimate(sessionId, new Estimate(userName, estimateValue));
       round = sessionManager.getRound(sessionId);
       results = sessionManager.getResults(sessionId);

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/AppControllerTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/AppControllerTest.java
@@ -10,6 +10,8 @@ class AppControllerTest {
 
   @Test
   void testGetAppVersionReturnsDevWhenNoManifest() {
+    // In test runs there is no MANIFEST.MF Implementation-Version attribute,
+    // so the controller falls back to "dev".
     String version = appController.getAppVersion();
     assertEquals("dev", version);
   }

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/GameControllerTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/GameControllerTest.java
@@ -204,7 +204,7 @@ class GameControllerTest extends AbstractControllerTest {
     Round stored = captor.getValue();
     assertEquals(2, stored.round());
     assertEquals("Login page", stored.label());
-    assertEquals("8", stored.consensus());
+    assertEquals("8", stored.consensus()); // explicit override preferred over mode
     assertEquals(votes, stored.votes());
     assertNotNull(stored.timestamp());
     verify(messagingUtils).sendRoundCompletedMessage(SESSION_ID, stored);

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/VoteControllerTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/VoteControllerTest.java
@@ -41,6 +41,11 @@ class VoteControllerTest extends AbstractControllerTest {
     inOrder.verifyNoMoreInteractions();
   }
 
+  /**
+   * Re-voting in the same round must replace the prior estimate (issue #111). The controller is no
+   * longer responsible for dedup — every vote unconditionally upserts via {@code
+   * SessionManager#registerEstimate}.
+   */
   @Test
   void testReVoteReplacesExistingEstimate() {
     String newValue = "8";
@@ -49,6 +54,7 @@ class VoteControllerTest extends AbstractControllerTest {
     when(sessionManager.getSessionLegalValues(SESSION_ID)).thenReturn(STORY_POINT_VALUES);
     when(sessionManager.getSessionUsers(SESSION_ID)).thenReturn(Lists.newArrayList(USER_NAME));
     when(sessionManager.getRound(SESSION_ID)).thenReturn(1);
+    // Source-of-truth post-upsert results: the new estimate has replaced the old one.
     when(sessionManager.getResults(SESSION_ID)).thenReturn(List.of(newEstimate));
 
     VoteResponse response = voteController.vote(SESSION_ID, USER_NAME, newValue);
@@ -58,6 +64,7 @@ class VoteControllerTest extends AbstractControllerTest {
     inOrder.verify(sessionManager, times(1)).isSessionActive(SESSION_ID);
     inOrder.verify(sessionManager, times(1)).getSessionLegalValues(SESSION_ID);
     inOrder.verify(sessionManager, times(1)).getSessionUsers(SESSION_ID);
+    // Crucial: registerEstimate is invoked even though a prior estimate exists for this user.
     inOrder.verify(sessionManager, times(1)).registerEstimate(SESSION_ID, newEstimate);
     inOrder.verify(sessionManager, times(1)).getRound(SESSION_ID);
     inOrder.verify(sessionManager, times(1)).getResults(SESSION_ID);

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/VotingAndResetConcurrencyTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/VotingAndResetConcurrencyTest.java
@@ -83,7 +83,7 @@ class VotingAndResetConcurrencyTest {
 
     int initialRound = sessionManager.getRound(sessionId);
     List<String> legalValues = sessionManager.getSessionLegalValues(sessionId);
-    String legal = legalValues.get(0);
+    String legal = legalValues.get(0); // any legal value is fine
 
     CountDownLatch start = new CountDownLatch(1);
     ExecutorService pool = Executors.newFixedThreadPool(memberCount + 1);

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/VotingAndResetSpecRegressionTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/VotingAndResetSpecRegressionTest.java
@@ -1,0 +1,103 @@
+package com.richashworth.planningpoker.controller;
+
+import static com.richashworth.planningpoker.common.PlanningPokerTestFixture.SESSION_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.Lists;
+import com.richashworth.planningpoker.model.CreateSessionRequest;
+import com.richashworth.planningpoker.model.Estimate;
+import com.richashworth.planningpoker.model.SessionResponse;
+import com.richashworth.planningpoker.model.VoteResponse;
+import com.richashworth.planningpoker.service.SessionManager;
+import com.richashworth.planningpoker.util.MessagingUtils;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+
+/**
+ * Regression tests anchored to the verified VotingAndReset.tla spec.
+ *
+ * <p>These tests document known divergences between the current backend and the spec's intended
+ * behaviour. Both are expected to FAIL against the current implementation and PASS once the
+ * corresponding fixes land.
+ *
+ * <ul>
+ *   <li><b>Issue #110</b> — Spec actions {@code ResetWithVotes} / {@code ResetEmpty} require {@code
+ *       Host \in connected}; only the host may trigger reset. Current backend's {@link
+ *       GameController#reset} accepts any session member.
+ *   <li><b>Issue #111</b> — Spec action {@code UpdateVote(m, v)} replaces the member's existing
+ *       vote with the new value. Current backend's {@link VoteController#vote} silently drops the
+ *       second vote.
+ * </ul>
+ */
+class VotingAndResetSpecRegressionTest extends AbstractControllerTest {
+
+  @InjectMocks private GameController gameController;
+
+  /**
+   * Spec property: {@code ResetWithVotes} / {@code ResetEmpty} guard {@code Host \in connected}.
+   * Issue #110 — non-host caller must be rejected with {@link HostActionException} (mapped to HTTP
+   * 403 by {@link ErrorHandler}).
+   *
+   * <p>This test will FAIL until the host-only check is added to {@link GameController#reset}.
+   */
+  @Test
+  void testResetByNonHostRejectedWith403() {
+    when(sessionManager.isSessionActive(SESSION_ID)).thenReturn(true);
+    when(sessionManager.getSessionUsers(SESSION_ID))
+        .thenReturn(Lists.newArrayList("HostUser", "GuestUser"));
+    // lenient() because the current (buggy) implementation never reads getHost during reset,
+    // so a strict stub would trip UnnecessaryStubbingException. Once issue #110 is fixed and
+    // reset() consults getHost(), the stub is exercised normally.
+    lenient().when(sessionManager.getHost(SESSION_ID)).thenReturn("HostUser");
+    // Same rationale: a host-checked reset short-circuits before reaching these. Today's reset
+    // calls them, so we stub leniently to keep the test compatible with both code paths.
+    lenient().when(sessionManager.getResults(SESSION_ID)).thenReturn(List.of());
+    lenient().when(sessionManager.incrementAndGetRound(SESSION_ID)).thenReturn(1);
+
+    assertThrows(
+        HostActionException.class,
+        () -> gameController.reset(SESSION_ID, "GuestUser", null),
+        "non-host /reset must be rejected (issue #110: spec says reset is host-only)");
+  }
+
+  /**
+   * Spec property: {@code UpdateVote(m, v)} replaces the member's prior vote when {@code
+   * serverVotes[m] # v}. Issue #111 — backend currently no-ops the second vote, leaving the
+   * original value in place.
+   *
+   * <p>End-to-end check using a real {@link SessionManager}: a single member votes "5", then
+   * re-votes "8". The recorded vote in the post-call results list must be "8".
+   *
+   * <p>This test will FAIL until {@link VoteController#vote} replaces (rather than ignores) the
+   * second vote.
+   */
+  @Test
+  void testReVoteReplacesOriginalValue() {
+    SessionManager realSessionManager = new SessionManager();
+    MessagingUtils stubMessaging = mock(MessagingUtils.class);
+    GameController gc = new GameController(realSessionManager, stubMessaging);
+    VoteController vc = new VoteController(realSessionManager, stubMessaging);
+
+    SessionResponse session =
+        gc.createSession(new CreateSessionRequest("Alice", "fibonacci", null, true));
+    String sessionId = session.sessionId();
+
+    vc.vote(sessionId, "Alice", "5");
+    VoteResponse second = vc.vote(sessionId, "Alice", "8");
+
+    assertEquals(
+        List.of(new Estimate("Alice", "8")),
+        second.results(),
+        "re-vote must replace the existing vote (issue #111: spec UpdateVote semantics)");
+    // Sanity: also assert against the source of truth, not just the response payload.
+    assertEquals(
+        List.of(new Estimate("Alice", "8")),
+        realSessionManager.getResults(sessionId),
+        "SessionManager must reflect the replaced vote");
+  }
+}

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/model/SchemeTypeTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/model/SchemeTypeTest.java
@@ -148,6 +148,7 @@ class SchemeTypeTest {
 
   @Test
   void testResolveCustomWithUnsureAlreadyIncluded() {
+    // If custom values already contain "?", enabling the toggle must not add a duplicate
     List<String> values = SchemeType.resolveValues("custom", "S,M,L,?", true);
     assertEquals(List.of("S", "M", "L", "?"), values);
     assertEquals(1, values.stream().filter("?"::equals).count());

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/service/SessionManagerTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/service/SessionManagerTest.java
@@ -46,9 +46,13 @@ class SessionManagerTest {
 
   @Test
   void testCreateSessionRejectsCollisions() {
+    // Creating many sessions should never produce duplicates
     for (int i = 0; i < 100; i++) {
       sessionManager.createSession();
     }
+    // All sessions are active (no collisions lost any)
+    // If there were a collision, the loop in createSession retries,
+    // so we just verify we got 100 distinct active sessions
   }
 
   @Test
@@ -227,12 +231,20 @@ class SessionManagerTest {
 
     sessionManager.evictIdleSessions();
 
+    // activeSessions
     assertFalse(sessionManager.isSessionActive(sessionId));
+    // sessionEstimates
     assertTrue(sessionManager.getResults(sessionId).isEmpty());
+    // sessionUsers
     assertTrue(sessionManager.getSessionUsers(sessionId).isEmpty());
+    // lastActivity — entry removed, so touching again would re-add but map should not contain old
+    // entry
     assertFalse(lastActivity.containsKey(sessionId));
+    // sessionLegalValues
     assertTrue(sessionManager.getSessionLegalValues(sessionId).isEmpty());
+    // sessionSchemeConfigs
     assertNull(sessionManager.getSessionSchemeConfig(sessionId));
+    // sessionHosts
     assertNull(sessionManager.getHost(sessionId));
   }
 
@@ -242,6 +254,7 @@ class SessionManagerTest {
     sessionManager.registerUser("Alice", activeSession);
     sessionManager.registerEstimate(activeSession, new Estimate("Alice", "3"));
 
+    // Do NOT backdate — session is active
     sessionManager.evictIdleSessions();
 
     assertTrue(sessionManager.isSessionActive(activeSession));
@@ -266,9 +279,11 @@ class SessionManagerTest {
 
     sessionManager.evictIdleSessions();
 
+    // Idle session is gone
     assertFalse(sessionManager.isSessionActive(idleSession));
     assertTrue(sessionManager.getSessionUsers(idleSession).isEmpty());
 
+    // Active session is fully intact
     assertTrue(sessionManager.isSessionActive(activeSession));
     assertEquals(List.of("Alice"), sessionManager.getSessionUsers(activeSession));
     assertEquals("Alice", sessionManager.getHost(activeSession));
@@ -276,6 +291,8 @@ class SessionManagerTest {
 
   @Test
   void testMaxSessionsLimit() {
+    // We can't easily create 100,000 sessions in a unit test, but we can verify the
+    // constant is set correctly
     assertEquals(100_000, SessionManager.MAX_SESSIONS);
   }
 
@@ -536,6 +553,7 @@ class SessionManagerTest {
     List<String> allSessions = new ArrayList<>();
     List<String> idleSessions = new ArrayList<>();
 
+    // Create 10 sessions each with one user
     for (int i = 0; i < sessionCount; i++) {
       String sessionId = sessionManager.createSession();
       sessionManager.registerUser("User" + i, sessionId);
@@ -557,6 +575,7 @@ class SessionManagerTest {
 
     List<String> activeSessions = allSessions.subList(5, sessionCount);
 
+    // Launch eviction thread
     CountDownLatch evictionStart = new CountDownLatch(1);
     CountDownLatch evictionDone = new CountDownLatch(1);
     Thread evictionThread =
@@ -602,7 +621,7 @@ class SessionManagerTest {
           });
     }
 
-    evictionStart.countDown();
+    evictionStart.countDown(); // ensure eviction starts
     readers.shutdown();
     assertTrue(readers.awaitTermination(15, TimeUnit.SECONDS));
     evictionDone.await(10, TimeUnit.SECONDS);

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/util/MessagingUtilsTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/util/MessagingUtilsTest.java
@@ -97,6 +97,7 @@ class MessagingUtilsTest {
     verify(template, times(1))
         .convertAndSend(eq(getTopic(TOPIC_RESULTS, SESSION_ID)), captor.capture());
     verifyNoMoreInteractions(template);
+    // Reflective check: payload is a Message record with type RESET_MESSAGE and {"round": 7}
     Object sent = captor.getValue();
     String str = sent.toString();
     org.junit.jupiter.api.Assertions.assertTrue(str.contains("RESET_MESSAGE"), str);

--- a/planningpoker-web/src/actions/index.js
+++ b/planningpoker-web/src/actions/index.js
@@ -30,6 +30,7 @@ export const voteOptimistic = (playerName, estimateValue) => ({
   payload: { userName: playerName, estimateValue },
 })
 
+// Events
 export const gameCreated = () => ({ type: GAME_CREATED })
 
 export const userRegistered = () => ({ type: USER_REGISTERED })
@@ -61,6 +62,7 @@ export const usersUpdated = (users) => ({ type: USERS_UPDATED, payload: users })
 
 export const kicked = () => ({ type: KICKED })
 
+// User-driven actions (thunks)
 export function createGame(playerName, schemeOptions, onSuccess) {
   return async (dispatch) => {
     try {

--- a/planningpoker-web/src/components/Logo.jsx
+++ b/planningpoker-web/src/components/Logo.jsx
@@ -9,6 +9,7 @@ export default function Logo({ size = 32, sx, ...props }) {
       sx={{ width: `${size}px`, height: `${size}px`, flexShrink: 0, ...sx }}
       {...props}
     >
+      {/* Back card */}
       <g transform="rotate(12, 16, 16)">
         <rect
           x="7"
@@ -22,6 +23,7 @@ export default function Logo({ size = 32, sx, ...props }) {
           strokeOpacity="0.4"
         />
       </g>
+      {/* Front card */}
       <g transform="rotate(-5, 16, 16)">
         <rect
           x="7"
@@ -34,6 +36,7 @@ export default function Logo({ size = 32, sx, ...props }) {
           strokeWidth="0.8"
           strokeOpacity="0.7"
         />
+        {/* Corner rank PP */}
         <text
           x="10"
           y="12.5"
@@ -45,6 +48,7 @@ export default function Logo({ size = 32, sx, ...props }) {
         >
           PP
         </text>
+        {/* Nautilus spiral — counter-clockwise, tapering */}
         <path
           d="M23,25 C23,20 21,16 17,15 C13,14 11,17 11,20 C11,23 13,24.5 15,24.5"
           stroke="white"

--- a/planningpoker-web/src/config/Constants.js
+++ b/planningpoker-web/src/config/Constants.js
@@ -1,4 +1,5 @@
 export const API_ROOT_URL = ''
+// export const API_ROOT_URL = 'http://localhost:9000';
 
 export const SCHEME_VALUES = {
   fibonacci: ['1', '2', '3', '5', '8', '13'],

--- a/planningpoker-web/src/containers/GamePane.jsx
+++ b/planningpoker-web/src/containers/GamePane.jsx
@@ -23,8 +23,9 @@ export default function GamePane({ connected }) {
   const autoConsensus = calcConsensus(results)
   const displayConsensus = consensusOverride || autoConsensus
 
-  // Dedup the reveal announcement off the voted state transition (not raw WS
-  // message arrival) so the server's burst of duplicate broadcasts is absorbed.
+  // Reveal announcement: fire once per voted false→true transition.
+  // Dedup is driven by the voted state transition, not raw WS message arrival,
+  // so MessagingUtils burst (10ms/50ms/150ms/500ms/2s/5s) is naturally handled.
   useEffect(() => {
     if (voted && !announcedForRevealRef.current) {
       setAnnouncement(`Votes revealed: ${results.length} of ${users.length} players voted`)
@@ -36,14 +37,17 @@ export default function GamePane({ connected }) {
     }
   }, [voted, results.length, users.length])
 
-  // First consensus announcement is deferred 1500ms so screen readers finish
-  // reading the reveal text before it gets overwritten; subsequent changes use
-  // a 750ms trailing-edge debounce.
+  // Consensus announcement: first value deferred 1500ms (to avoid overwriting reveal
+  // announcement in screen readers), subsequent changes debounced 750ms trailing edge.
   useEffect(() => {
     if (!voted) return
     if (!displayConsensus) return
     if (displayConsensus === lastAnnouncedConsensusRef.current) return
 
+    // Both first and subsequent announcements go through debounce to avoid
+    // overwriting the reveal announcement that fires on the same render cycle.
+    // First: 1500ms (lets screen readers announce reveal first).
+    // Subsequent: 750ms trailing edge.
     const delay = lastAnnouncedConsensusRef.current === null ? 1500 : 750
 
     if (consensusDebounceRef.current) clearTimeout(consensusDebounceRef.current)

--- a/planningpoker-web/src/containers/__tests__/Header.test.jsx
+++ b/planningpoker-web/src/containers/__tests__/Header.test.jsx
@@ -43,6 +43,7 @@ function renderHeader(state = preloaded()) {
 describe('Header container', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Writable clipboard stub
     Object.defineProperty(navigator, 'clipboard', {
       value: { writeText: vi.fn(() => Promise.resolve()) },
       configurable: true,
@@ -62,8 +63,8 @@ describe('Header container', () => {
   it('writes the session id to the clipboard when the copy icon is clicked', async () => {
     renderHeader()
 
-    // The Chip's delete icon is the copy control; it has no accessible name,
-    // so reach for it via the chip wrapper.
+    // The Chip's delete icon is the copy control — it has no accessible name but
+    // sits inside a tooltip.
     const chip = screen.getByText(/Session ID:/).closest('.MuiChip-root')
     const copyButton = chip.querySelector('.MuiChip-deleteIcon')
     await act(async () => {

--- a/planningpoker-web/src/containers/__tests__/ResultsTable.test.jsx
+++ b/planningpoker-web/src/containers/__tests__/ResultsTable.test.jsx
@@ -46,6 +46,7 @@ describe('ResultsTable container', () => {
         users: ['alice', 'bob'],
       }),
     })
+    // Bob should appear as a non-voter
     expect(screen.getByText('Bob')).toBeInTheDocument()
   })
 })

--- a/planningpoker-web/src/containers/__tests__/SessionHistory.test.jsx
+++ b/planningpoker-web/src/containers/__tests__/SessionHistory.test.jsx
@@ -69,6 +69,7 @@ describe('SessionHistory container', () => {
         results: [{ userName: 'alice', estimateValue: '3' }],
       }),
     })
+    // No completed rounds yet → non-collapsible caption, but export is still available
     expect(screen.getByText(/Session history · 1 round/)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Export CSV/ })).toBeInTheDocument()
   })

--- a/planningpoker-web/src/containers/__tests__/UsersTable.test.jsx
+++ b/planningpoker-web/src/containers/__tests__/UsersTable.test.jsx
@@ -57,6 +57,7 @@ describe('UsersTable container', () => {
     renderWithStore(<UsersTable heading="Players" />, {
       preloadedState: state({ playerName: 'alice', host: 'alice', users: ['alice', 'bob'] }),
     })
+    // One transfer button and one kick button — for bob
     const transferButtons = screen
       .getAllByRole('button')
       .filter((b) => b.querySelector('[data-testid="SwapHorizRoundedIcon"]'))

--- a/planningpoker-web/src/hooks/__tests__/useStomp.test.js
+++ b/planningpoker-web/src/hooks/__tests__/useStomp.test.js
@@ -1,9 +1,30 @@
 // @vitest-environment jsdom
+/**
+ * useStomp hook tests.
+ *
+ * Mounts the real hook via `renderHook` from @testing-library/react with
+ * @stomp/stompjs and sockjs-client mocked at module level. Asserts on the
+ * mocked Client constructor calls, activate/deactivate, subscribe per topic,
+ * and the onMessage JSON-parse + dispatch path.
+ *
+ * Covered:
+ *   - Client is NOT constructed when url/topics are empty
+ *   - client.activate() is called on mount
+ *   - onConnect subscribes to every requested topic
+ *   - Incoming STOMP message is JSON-parsed and forwarded to onMessage
+ *   - client.deactivate() is called on cleanup (when active)
+ *   - deactivate is NOT called when client is already inactive
+ *   - connected state transitions for connect/disconnect/error/close
+ *   - disconnect/error before initial connect is ignored
+ *   - reconnect resubscribes to all topics
+ *   - latest onMessage callback is used (ref-tracked, not re-mounted)
+ */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 
-// vi.mock calls are hoisted above imports, so these refs are populated by the
-// time `import useStomp` runs.
+// ---------------------------------------------------------------------------
+// Module-level mocks — declared via vi.mock so they're hoisted before imports.
+// ---------------------------------------------------------------------------
 let lastClientConfig = null
 let lastClientInstance = null
 
@@ -30,7 +51,7 @@ import { Client } from '@stomp/stompjs'
 import SockJS from 'sockjs-client'
 import useStomp from '../useStomp'
 
-// Stable references so the [url, topics] effect doesn't re-fire on rerender.
+// Stable topics arrays so we don't trigger the [url, topics] effect via referential changes.
 const ONE_TOPIC = ['/topic/results/abc']
 const TWO_TOPICS = ['/topic/results/abc', '/topic/users/abc']
 
@@ -70,6 +91,7 @@ describe('useStomp — STOMP client wiring', () => {
     )
     expect(Client).toHaveBeenCalledTimes(1)
     expect(lastClientInstance.activate).toHaveBeenCalledOnce()
+    // Invoke the webSocketFactory the hook passed in, to confirm SockJS is wired.
     lastClientConfig.webSocketFactory()
     expect(SockJS).toHaveBeenCalledWith('http://localhost:9000/stomp')
   })

--- a/planningpoker-web/src/hooks/useStomp.js
+++ b/planningpoker-web/src/hooks/useStomp.js
@@ -5,12 +5,13 @@ import SockJS from 'sockjs-client'
 export default function useStomp({ url, topics, onMessage }) {
   const onMessageRef = useRef(onMessage)
   onMessageRef.current = onMessage
-  const [connected, setConnected] = useState(null) // null = not yet attempted; false = banner shown
+  const [connected, setConnected] = useState(null) // null = not yet attempted
   const hasConnected = useRef(false)
 
   useEffect(() => {
     if (!url || !topics || topics.length === 0) return
 
+    // If not connected after 5s, show the banner
     const timeout = setTimeout(() => {
       if (!hasConnected.current) setConnected(false)
     }, 5000)

--- a/planningpoker-web/src/pages/__tests__/PlayGame.reconnect.test.jsx
+++ b/planningpoker-web/src/pages/__tests__/PlayGame.reconnect.test.jsx
@@ -1,9 +1,26 @@
 // @vitest-environment jsdom
+/**
+ * PlayGame — reconnect session validation + epoch message routing.
+ *
+ * Mounts the real PlayGame component via `renderWithStore` with `useStomp`
+ * mocked at module level. The mock captures the latest `{ url, topics, onMessage }`
+ * arguments and exposes the captured callback so tests can fire fake STOMP
+ * messages through it and assert on resulting Redux state and rendered output.
+ *
+ * Covers:
+ *   - reconnect session validation: GET /sessionUsers fires only after
+ *     prior connection, dispatches `kicked()` on 404 and stores message.
+ *   - epoch message routing for RESULTS_MESSAGE / RESET_MESSAGE / USER_LEFT_MESSAGE
+ *     (drop-stale / replace / union behaviour driven through the real reducers).
+ */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { act, cleanup, screen } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 import { MemoryRouter } from 'react-router-dom'
 
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
 const stompCapture = { url: null, topics: null, onMessage: null }
 
 vi.mock('../../hooks/useStomp', () => ({
@@ -107,6 +124,7 @@ describe('PlayGame — epoch message routing', () => {
 
   it('unions results on RESULTS_MESSAGE with equal round', () => {
     const { store } = mountPlayGame({ clientRound: 3 })
+    // Seed an existing result via action dispatch.
     act(() => {
       store.dispatch({
         type: 'results-replace',
@@ -161,7 +179,7 @@ describe('PlayGame — epoch message routing', () => {
   it('drops RESET_MESSAGE with stale round', () => {
     const { store } = mountPlayGame({ clientRound: 3 })
 
-    // Seed state so that a successful RESET would be observable.
+    // Seed some state to ensure RESET would have been observable.
     act(() => {
       store.dispatch({
         type: 'results-replace',
@@ -274,6 +292,7 @@ describe('PlayGame — epoch message routing', () => {
 
 describe('PlayGame — reconnect session validation', () => {
   it('does not GET /sessionUsers on initial connect (only refresh fires)', async () => {
+    // First render with connected=null so the connected effect doesn't fire.
     stompCapture.connected = null
     const { rerender, store } = renderWithStore(
       <MemoryRouter>
@@ -282,6 +301,7 @@ describe('PlayGame — reconnect session validation', () => {
       { preloadedState: preloadedState() },
     )
 
+    // Now flip the mock's return to connected=true and rerender.
     stompCapture.connected = true
     await act(async () => {
       rerender(
@@ -291,6 +311,7 @@ describe('PlayGame — reconnect session validation', () => {
       )
     })
 
+    // Initial connect should NOT call /sessionUsers — only /refresh.
     const sessionUsersCalls = axios.get.mock.calls.filter(([u]) =>
       String(u).includes('/sessionUsers'),
     )
@@ -299,6 +320,7 @@ describe('PlayGame — reconnect session validation', () => {
     const refreshCalls = axios.get.mock.calls.filter(([u]) => String(u).includes('/refresh'))
     expect(refreshCalls.length).toBeGreaterThan(0)
 
+    // Quiet unused-store warnings.
     expect(store.getState().game.sessionId).toBe('abc12345')
   })
 
@@ -311,6 +333,7 @@ describe('PlayGame — reconnect session validation', () => {
       { preloadedState: preloadedState() },
     )
 
+    // Drop the connection.
     stompCapture.connected = false
     await act(async () => {
       rerender(
@@ -323,6 +346,7 @@ describe('PlayGame — reconnect session validation', () => {
     axios.get.mockClear()
     axios.get.mockResolvedValue({ data: ['alice'] })
 
+    // Reconnect.
     stompCapture.connected = true
     await act(async () => {
       rerender(
@@ -331,6 +355,7 @@ describe('PlayGame — reconnect session validation', () => {
         </MemoryRouter>,
       )
     })
+    // Allow .then to flush.
     await act(async () => {
       await Promise.resolve()
     })
@@ -339,6 +364,7 @@ describe('PlayGame — reconnect session validation', () => {
       String(u).includes('/sessionUsers'),
     )
     expect(sessionUsersCalls.length).toBeGreaterThan(0)
+    // Server-restart kicked message should NOT be set on a successful response.
     expect(sessionStorage.getItem('pp-kicked-message')).toBeNull()
   })
 
@@ -379,6 +405,7 @@ describe('PlayGame — reconnect session validation', () => {
     expect(sessionStorage.getItem('pp-kicked-message')).toBe(
       'The session ended because the server was restarted.',
     )
+    // KICKED resets game state; isRegistered drops back to false.
     expect(store.getState().game.isRegistered).toBe(false)
   })
 })
@@ -395,8 +422,9 @@ describe('PlayGame — render guard', () => {
       { preloadedState: state },
     )
 
-    // GamePane renders before the navigate effect runs, so we just assert
-    // that the redirect path doesn't blow up here.
+    // GamePane does still render but the component would have triggered a navigate.
+    // Voting affordance from GamePane should still be present (component renders before navigate effect runs).
+    // We just assert no crash and the cast-vote affordance is wired up.
     expect(screen.queryByText(/Reconnecting/)).not.toBeInTheDocument()
   })
 })

--- a/planningpoker-web/src/reducers/__tests__/reducer_results.test.js
+++ b/planningpoker-web/src/reducers/__tests__/reducer_results.test.js
@@ -53,8 +53,11 @@ describe('results reducer', () => {
     expect(reducer([], action)).toEqual([{ userName: 'alice', estimateValue: '5' }])
   })
 
-  // Regression: a VOTE rejection after VOTE_OPTIMISTIC must drop the optimistic
-  // row so the UI doesn't keep showing a vote the server never accepted.
+  // Regression test for the asymmetric optimistic-revert (issue #117). When
+  // VOTE rejects after VOTE_OPTIMISTIC has populated the user's row, the
+  // optimistic entry must be removed so the UI doesn't keep showing a vote
+  // the server never accepted. This test depends on the reducer change in
+  // PR #117; it will fail on master until that PR merges.
   it('removes optimistic entry when VOTE rejects (asymmetric revert)', () => {
     const optimistic = reducer([], {
       type: VOTE_OPTIMISTIC,

--- a/planningpoker-web/src/reducers/index.js
+++ b/planningpoker-web/src/reducers/index.js
@@ -6,6 +6,7 @@ import VoteReducer from './reducer_vote'
 import NotificationReducer from './reducer_notification'
 import RoundsReducer from './reducer_rounds'
 
+//keys define what pieces of state each reducer manages
 const rootReducer = combineReducers({
   game: GameReducer,
   results: ResultsReducer,

--- a/planningpoker-web/src/utils/csvExport.test.js
+++ b/planningpoker-web/src/utils/csvExport.test.js
@@ -93,15 +93,18 @@ describe('generateCsv', () => {
     ]
     const csv = generateCsv(round, ['Alice'])
     const lines = csv.split('\n')
+    // Should be wrapped and start with ' prefix
     expect(lines[1].startsWith('"\'=SUM(A1)"') || lines[1].startsWith("'=SUM(A1)")).toBe(true)
   })
 })
 
 describe('downloadCsv', () => {
   beforeEach(() => {
+    // Mock URL.createObjectURL and URL.revokeObjectURL
     globalThis.URL.createObjectURL = vi.fn(() => 'blob:mock-url')
     globalThis.URL.revokeObjectURL = vi.fn()
 
+    // Mock document.createElement and document.body
     const mockLink = {
       href: '',
       download: '',

--- a/planningpoker-web/tests/planning-poker.spec.js
+++ b/planningpoker-web/tests/planning-poker.spec.js
@@ -107,17 +107,20 @@ test.describe('Dark/Light Mode', () => {
     const LIGHT_BG = 'rgb(248, 250, 252)'
     const toggle = page.getByRole('button', { name: 'Toggle dark mode' })
 
+    // Default with dark OS preference is dark mode
     await page.waitForFunction(
       (expected) => getComputedStyle(document.body).backgroundColor === expected,
       DARK_BG,
     )
 
+    // Toggle to light mode
     await toggle.click()
     await page.waitForFunction(
       (expected) => getComputedStyle(document.body).backgroundColor === expected,
       LIGHT_BG,
     )
 
+    // Toggle back to dark mode
     await toggle.click()
     await page.waitForFunction(
       (expected) => getComputedStyle(document.body).backgroundColor === expected,
@@ -196,11 +199,12 @@ test.describe('Multi-User Flows', () => {
       await route.continue()
     })
 
+    // Bob logs himself out
     await playerPage.getByRole('button', { name: /Bob/i }).click()
     await playerPage.getByRole('menuitem', { name: 'Log out' }).click()
     await expect(playerPage).toHaveURL('/')
 
-    // No "removed by the host" toast should appear, even after a small delay
+    // No "removed by the host" toast should appear, immediately or after a beat
     await expect(playerPage.getByText(/removed from the session by the host/i)).not.toBeVisible()
     await playerPage.waitForTimeout(500)
     await expect(playerPage.getByText(/removed from the session by the host/i)).not.toBeVisible()
@@ -298,6 +302,7 @@ test.describe('Multi-User Flows', () => {
     const p3Page = await p3Ctx.newPage()
     await joinGame(p3Page, 'Charlie', sessionId)
 
+    // All vote (stagger slightly to avoid race)
     await hostPage.getByText('5', { exact: true }).click()
     await p2Page.getByText('8', { exact: true }).click()
     await p3Page.getByText('5', { exact: true }).click()

--- a/planningpoker-web/tests/session-labels-csv.spec.js
+++ b/planningpoker-web/tests/session-labels-csv.spec.js
@@ -63,6 +63,7 @@ test.describe('Session Labels', () => {
       // Non-host should NOT have a label input
       await expect(playerPage.getByPlaceholder('Item label (optional)')).not.toBeVisible()
 
+      // Wait for player WebSocket to deliver USERS_MESSAGE (host name appears in users list)
       await waitForWsReady(playerPage, sessionId, 'Alice')
 
       // Host types a label and presses Enter to commit
@@ -90,6 +91,7 @@ test.describe('Session Labels', () => {
       const playerPage = await playerCtx.newPage()
       await joinGame(playerPage, 'Bob', sessionId)
 
+      // Wait for player WebSocket to deliver USERS_MESSAGE (host name appears in users list)
       await waitForWsReady(playerPage, sessionId, 'Alice')
 
       // Host opens the banner, sets a label and commits with Enter
@@ -128,6 +130,7 @@ test.describe('Session Labels', () => {
       const playerPage = await playerCtx.newPage()
       await joinGame(playerPage, 'Bob', sessionId)
 
+      // Wait for player WebSocket to deliver USERS_MESSAGE (host name appears in users list)
       await waitForWsReady(playerPage, sessionId, 'Alice')
 
       // Host opens banner, sets label and commits with Enter
@@ -165,13 +168,15 @@ test.describe('Session Labels', () => {
       const playerPage = await playerCtx.newPage()
       await joinGame(playerPage, 'Bob', sessionId)
 
+      // Wait for player WebSocket to deliver USERS_MESSAGE (host name appears in users list)
       await waitForWsReady(playerPage, sessionId, 'Alice')
 
       const labelInput = hostPage.getByPlaceholder('Item label (optional)')
 
+      // Host types — do not yet commit. Non-host should NOT see it within debounce window.
       await labelInput.fill('Deliberate')
-      // Commit explicitly with Enter; deterministic and faster than the
-      // typing-debounce broadcast.
+
+      // Commit explicitly with Enter (deterministic, faster than debounce)
       await labelInput.press('Enter')
       await expect(playerPage.getByText('Deliberate')).toBeVisible({
         timeout: 15000,
@@ -192,6 +197,7 @@ test.describe('Session Labels', () => {
       const playerPage = await playerCtx.newPage()
       await joinGame(playerPage, 'Bob', sessionId)
 
+      // Wait for player WebSocket to deliver USERS_MESSAGE (host name appears in users list)
       await waitForWsReady(playerPage, sessionId, 'Alice')
 
       const labelInput = hostPage.getByPlaceholder('Item label (optional)')
@@ -220,6 +226,7 @@ test.describe('Session Labels', () => {
       const playerPage = await playerCtx.newPage()
       await joinGame(playerPage, 'Bob', sessionId)
 
+      // Wait for player WebSocket to deliver USERS_MESSAGE (host name appears in users list)
       await waitForWsReady(playerPage, sessionId, 'Alice')
 
       const labelInput = hostPage.getByPlaceholder('Item label (optional)')
@@ -346,6 +353,7 @@ test.describe('CSV Export', () => {
       const playerPage = await playerCtx.newPage()
       await joinGame(playerPage, 'Bob', sessionId)
 
+      // Wait for player WebSocket to deliver USERS_MESSAGE (host name appears in users list)
       await waitForWsReady(playerPage, sessionId, 'Alice')
 
       // Set label via banner → Enter commit


### PR DESCRIPTION
## Summary
- Reverts `eb10421` (chore: prune stale and redundant comments) and `34fbd12` (test(api): remove redundant VotingAndResetSpecRegressionTest), which were pushed directly to master, bypassing the 5 required status checks.
- The cleanup itself was verified locally (lint, spotless, 163 backend tests, 176 frontend tests all green) but never ran through full CI (e2e, etc.).
- Once this revert lands via normal CI, the same cleanup will be re-opened as a fresh PR so it merges through the gated path.

## Test plan
- [ ] Lint job passes
- [ ] Backend unit tests pass
- [ ] E2E tests pass
- [ ] Re-open `chore/prune-stale-comments` PR after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)