### PR TITLE
chore(web): re-prettier GamePane ternary to fix master

### DIFF
--- a/planningpoker-web/src/containers/GamePane.jsx
+++ b/planningpoker-web/src/containers/GamePane.jsx
@@ -85,11 +85,7 @@ export default function GamePane({ connected }) {
       <LiveAnnouncer message={announcement} />
       <Box>
         <SessionHeader />
-        {voted ? (
-          <Results />
-        ) : (
-          <Vote consensusOverride={consensusOverride} />
-        )}
+        {voted ? <Results /> : <Vote consensusOverride={consensusOverride} />}
       </Box>
     </>
   )


### PR DESCRIPTION
## Summary
- Squash merge of #127 landed a multi-line ternary in `GamePane.jsx` that prettier wants collapsed onto one line. Master CI is currently failing on `format:check`, blocking semantic-release.
- This runs prettier --write on the affected file to restore green.

## Test plan
- [x] `npm run format:check` clean locally
- [x] No functional change (only whitespace inside a JSX ternary)