### PR TITLE
chore(web): migrate to MUI slotProps + React Router v7 future flags

### DIFF
--- a/planningpoker-web/src/App.jsx
+++ b/planningpoker-web/src/App.jsx
@@ -38,7 +38,7 @@ function AppInner({ theme, toggleColorMode, mode }) {
     <ColorModeContext.Provider value={{ toggleColorMode, mode }}>
       <ThemeProvider theme={theme}>
         <CssBaseline />
-        <BrowserRouter>
+        <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
           <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
             <Header />
             <Toolbar />

--- a/planningpoker-web/src/components/NameInput.jsx
+++ b/planningpoker-web/src/components/NameInput.jsx
@@ -9,9 +9,11 @@ export default function NameInput({ playerName, onPlayerNameInputChange }) {
       autoFocus
       required
       fullWidth
-      inputProps={{
-        pattern: '[a-zA-Z0-9 _\\-]{3,20}',
-        title: 'Name must be 3-20 characters: letters, numbers, spaces, hyphens, or underscores',
+      slotProps={{
+        htmlInput: {
+          pattern: '[a-zA-Z0-9 _\\-]{3,20}',
+          title: 'Name must be 3-20 characters: letters, numbers, spaces, hyphens, or underscores',
+        },
       }}
       sx={{ mb: 2.5 }}
     />

--- a/planningpoker-web/src/containers/SessionHeader.jsx
+++ b/planningpoker-web/src/containers/SessionHeader.jsx
@@ -103,18 +103,20 @@ export default function SessionHeader() {
               onChange={handleLabelChange}
               onBlur={handleBlur}
               onKeyDown={handleKeyDown}
-              inputProps={{ maxLength: 100 }}
-              InputProps={{
-                endAdornment: justSaved ? (
-                  <InputAdornment position="end">
-                    <Typography
-                      variant="caption"
-                      sx={{ color: 'success.main', whiteSpace: 'nowrap' }}
-                    >
-                      ✓ Saved
-                    </Typography>
-                  </InputAdornment>
-                ) : null,
+              slotProps={{
+                htmlInput: { maxLength: 100 },
+                input: {
+                  endAdornment: justSaved ? (
+                    <InputAdornment position="end">
+                      <Typography
+                        variant="caption"
+                        sx={{ color: 'success.main', whiteSpace: 'nowrap' }}
+                      >
+                        ✓ Saved
+                      </Typography>
+                    </InputAdornment>
+                  ) : null,
+                },
               }}
             />
           ) : (

--- a/planningpoker-web/src/pages/JoinGame.jsx
+++ b/planningpoker-web/src/pages/JoinGame.jsx
@@ -56,7 +56,7 @@ export default function JoinGame() {
               fullWidth
               sx={{ mb: 2.5 }}
               helperText="8-character session ID"
-              inputProps={{ maxLength: 8 }}
+              slotProps={{ htmlInput: { maxLength: 8 } }}
             />
             <Button
               type="submit"


### PR DESCRIPTION
## Summary

Silences the two pre-existing console-warning sources that became visible during the React 19 upgrade run (#143):

- **MUI v9** deprecates passing `inputProps` / `InputProps` directly on `TextField` in favor of `slotProps.htmlInput` / `slotProps.input`. Migrated three call sites:
  - `NameInput.jsx` — name-input pattern + title
  - `JoinGame.jsx` — session-ID `maxLength: 8`
  - `SessionHeader.jsx` — label `maxLength: 100` and the "✓ Saved" `endAdornment`
- **React Router 6** will change behavior under v7 for state-update wrapping (`v7_startTransition`) and splat-route relative resolution (`v7_relativeSplatPath`). Opted in now so the warnings stop and the eventual v7 upgrade is a no-op for these flags.

No functional changes — purely API-shape migrations.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm run test` — 220/220 unit tests pass
- [x] `npx playwright test` — 43/43 e2e tests pass
- [x] Console output during e2e run no longer contains `inputProps` / `InputProps` / `React Router Future Flag` warnings