### PR TITLE
feat(web): redesign chart consensus highlight (V8)

### DIFF
--- a/planningpoker-web/src/containers/Results.jsx
+++ b/planningpoker-web/src/containers/Results.jsx
@@ -1,12 +1,22 @@
 import { useSelector, useDispatch } from 'react-redux'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
+import Typography from '@mui/material/Typography'
 import ResultsTable from './ResultsTable'
 import ResultsChart from './ResultsChart'
 import SessionHistory from './SessionHistory'
 import ConsensusCardRail from '../components/ConsensusCardRail'
 import { resetSession, setConsensusOverride } from '../actions'
 import { calcConsensus } from '../utils/consensus'
+
+const eyebrowSx = {
+  fontSize: 10,
+  fontWeight: 600,
+  letterSpacing: '0.08em',
+  textTransform: 'uppercase',
+  color: 'text.secondary',
+  lineHeight: 1,
+}
 
 export default function Results() {
   const dispatch = useDispatch()
@@ -19,6 +29,9 @@ export default function Results() {
 
   const autoConsensus = calcConsensus(results)
   const displayConsensus = consensusOverride || autoConsensus
+  const consensusCount = displayConsensus
+    ? results.filter((r) => r.estimateValue === displayConsensus).length
+    : 0
 
   const handleNextItem = () => {
     const consensus = consensusOverride || calcConsensus(results) || ''
@@ -95,10 +108,62 @@ export default function Results() {
               border: '1px solid',
               borderColor: 'divider',
               borderRadius: 1,
-              p: 2.5,
+              padding: '14px 16px 8px',
               transition: 'border-color 0.3s ease, background-color 0.3s ease',
             }}
           >
+            {displayConsensus && (
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'baseline',
+                  justifyContent: 'space-between',
+                  mb: 1,
+                }}
+              >
+                <Typography component="span" sx={eyebrowSx}>
+                  Distribution
+                </Typography>
+                <Box
+                  sx={{
+                    display: 'inline-flex',
+                    alignItems: 'baseline',
+                    gap: 0.75,
+                  }}
+                >
+                  <Typography component="span" sx={eyebrowSx}>
+                    Consensus
+                  </Typography>
+                  <Typography
+                    component="span"
+                    sx={{
+                      fontSize: 13,
+                      fontWeight: 700,
+                      color: 'primary.main',
+                      fontVariantNumeric: 'tabular-nums',
+                      lineHeight: 1,
+                    }}
+                  >
+                    {displayConsensus}
+                  </Typography>
+                  <Typography
+                    component="span"
+                    aria-hidden="true"
+                    sx={{ color: 'text.disabled', fontSize: 11, lineHeight: 1 }}
+                  >
+                    ·
+                  </Typography>
+                  <Typography
+                    component="span"
+                    sx={{ fontSize: 11, color: 'text.secondary', lineHeight: 1 }}
+                  >
+                    {consensusCount === 0
+                      ? 'no votes'
+                      : `${consensusCount} ${consensusCount === 1 ? 'vote' : 'votes'}`}
+                  </Typography>
+                </Box>
+              </Box>
+            )}
             <ResultsChart consensus={displayConsensus} />
           </Box>
         </Box>

--- a/planningpoker-web/src/containers/ResultsChart.jsx
+++ b/planningpoker-web/src/containers/ResultsChart.jsx
@@ -4,39 +4,48 @@ import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Tooltip } fro
 import { Bar } from 'react-chartjs-2'
 ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip)
 
-const DEFAULT_BG = 'rgba(102, 126, 234, 0.35)'
-const DEFAULT_BORDER = 'rgba(102, 126, 234, 0.7)'
-const DEFAULT_HOVER_BG = 'rgba(102, 126, 234, 0.55)'
-const HIGHLIGHT_BG = 'rgba(102, 126, 234, 0.85)'
-const HIGHLIGHT_BORDER = 'rgba(102, 126, 234, 1)'
-const HIGHLIGHT_HOVER_BG = 'rgba(102, 126, 234, 0.95)'
-
-// Draws a stroked circle around the consensus tick label when that estimate
-// has zero votes — the bar already carries the highlight when votes exist,
-// so we only ring the tick when there's no bar to color.
-const consensusAxisHighlightPlugin = {
-  id: 'consensusAxisHighlight',
+// Solid pill behind the consensus tick label, label re-drawn in white on top.
+const consensusAxisPillPlugin = {
+  id: 'consensusAxisPill',
   afterDraw(chart, _args, opts) {
     if (!opts) return
-    const { consensus, legalEstimates, aggregateData } = opts
+    const { consensus, legalEstimates, pillBg, pillFg } = opts
     if (consensus == null) return
     const idx = legalEstimates.indexOf(consensus)
-    if (idx === -1 || aggregateData[idx] !== 0) return
+    if (idx === -1) return
 
     const xScale = chart.scales.x
     if (!xScale) return
-    const xCenter = xScale.getPixelForValue(idx)
-    // Tick labels sit below the axis line; aim for the vertical centre of
-    // the label band rather than the axis line itself.
-    const yCenter = xScale.top + xScale.height * 0.55
-
     const ctx = chart.ctx
+
+    const label = String(consensus)
+    const fontSize = 12
+    const padX = 10
+    const padY = 3
+
     ctx.save()
-    ctx.strokeStyle = HIGHLIGHT_BORDER
-    ctx.lineWidth = 2
-    ctx.beginPath()
-    ctx.arc(xCenter, yCenter, 13, 0, Math.PI * 2)
-    ctx.stroke()
+    const fontFamily = (chart.canvas && getComputedStyle(chart.canvas).fontFamily) || 'sans-serif'
+    ctx.font = `700 ${fontSize}px ${fontFamily}`
+    const textWidth = ctx.measureText(label).width
+    const pillW = textWidth + padX * 2
+    const pillH = fontSize + padY * 2
+
+    const cx = xScale.getPixelForValue(idx)
+    const cy = xScale.top + xScale.height * 0.55
+
+    ctx.fillStyle = pillBg
+    if (typeof ctx.roundRect === 'function') {
+      ctx.beginPath()
+      ctx.roundRect(cx - pillW / 2, cy - pillH / 2, pillW, pillH, 999)
+      ctx.fill()
+    } else {
+      ctx.fillRect(cx - pillW / 2, cy - pillH / 2, pillW, pillH)
+    }
+
+    ctx.fillStyle = pillFg
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'middle'
+    ctx.fillText(label, cx, cy)
     ctx.restore()
   },
 }
@@ -51,29 +60,30 @@ export default function ResultsChart({ consensus = null }) {
 
   const tickColor = theme.palette.text.secondary
   const gridColor = theme.palette.divider
+  const barColor = theme.palette.primary.main
+  const barMutedColor = theme.palette.chart.barMuted
 
   const isHighlighted = (label) => consensus != null && label === consensus
-  const backgroundColor = legalEstimates.map((l) => (isHighlighted(l) ? HIGHLIGHT_BG : DEFAULT_BG))
-  const borderColor = legalEstimates.map((l) =>
-    isHighlighted(l) ? HIGHLIGHT_BORDER : DEFAULT_BORDER,
-  )
-  const hoverBackgroundColor = legalEstimates.map((l) =>
-    isHighlighted(l) ? HIGHLIGHT_HOVER_BG : DEFAULT_HOVER_BG,
-  )
-  const borderWidth = legalEstimates.map((l) => (isHighlighted(l) ? 2 : 1))
+  const backgroundColor = legalEstimates.map((l) => (isHighlighted(l) ? barColor : barMutedColor))
+  const borderColor = backgroundColor
+  const borderWidth = legalEstimates.map(() => 0)
+  const hoverBackgroundColor = backgroundColor
 
-  // Always highlight the consensus tick label so the axis stays in sync with
-  // the bar, even when the bar happens to have zero votes (no fill to see).
-  const isConsensusTick = (idx) => isHighlighted(legalEstimates[idx])
-  const xTickColor = (ctx) => (isConsensusTick(ctx.index) ? HIGHLIGHT_BORDER : tickColor)
-  const xTickFont = (ctx) => (isConsensusTick(ctx.index) ? { weight: 'bold' } : {})
+  // Hide the underlying tick label for the consensus index — the axis-pill
+  // plugin re-draws it in white on top, and we don't want kerning bleed.
+  const xTickColor = (ctx) => (isHighlighted(legalEstimates[ctx.index]) ? 'transparent' : tickColor)
 
   const options = {
     responsive: true,
     plugins: {
       legend: { display: false },
       tooltip: { enabled: false },
-      consensusAxisHighlight: { consensus, legalEstimates, aggregateData },
+      consensusAxisPill: {
+        consensus,
+        legalEstimates,
+        pillBg: theme.palette.primary.main,
+        pillFg: '#fff',
+      },
     },
     scales: {
       y: {
@@ -86,7 +96,7 @@ export default function ResultsChart({ consensus = null }) {
         border: { color: gridColor },
       },
       x: {
-        ticks: { color: xTickColor, font: xTickFont },
+        ticks: { color: xTickColor, font: { size: 12, weight: 500 } },
         grid: { color: 'transparent' },
         border: { color: gridColor },
       },
@@ -107,5 +117,5 @@ export default function ResultsChart({ consensus = null }) {
     ],
   }
 
-  return <Bar options={options} data={data} plugins={[consensusAxisHighlightPlugin]} />
+  return <Bar options={options} data={data} plugins={[consensusAxisPillPlugin]} />
 }

--- a/planningpoker-web/src/containers/__tests__/Results.test.jsx
+++ b/planningpoker-web/src/containers/__tests__/Results.test.jsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { screen, fireEvent, act, cleanup } from '@testing-library/react'
+import { screen, fireEvent, act, cleanup, within } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 
 vi.mock('axios', () => ({
@@ -101,5 +101,37 @@ describe('Results container', () => {
 
     const [, params] = axios.post.mock.calls.find(([url]) => /\/setConsensus$/.test(url))
     expect(params.has('value')).toBe(false)
+  })
+
+  it('renders the chart header summary with the consensus value and vote ratio', () => {
+    renderWithStore(<Results />, { preloadedState: baseState() })
+    const headerRow = screen.getByText('Distribution').parentElement
+    expect(headerRow).toBeInTheDocument()
+    expect(within(headerRow).getByText('Consensus')).toBeInTheDocument()
+    expect(within(headerRow).getByText('5')).toBeInTheDocument()
+    expect(within(headerRow).getByText('2 votes')).toBeInTheDocument()
+  })
+
+  it('shows "no votes" in the header when the consensus has zero votes', () => {
+    renderWithStore(<Results />, {
+      preloadedState: baseState({ consensus: { value: '8', round: 0 } }),
+    })
+    const headerRow = screen.getByText('Distribution').parentElement
+    expect(within(headerRow).getByText('Consensus')).toBeInTheDocument()
+    expect(within(headerRow).getByText('8')).toBeInTheDocument()
+    expect(within(headerRow).getByText('no votes')).toBeInTheDocument()
+  })
+
+  it('hides the chart header summary when no consensus exists yet', () => {
+    renderWithStore(<Results />, {
+      preloadedState: baseState({
+        results: [],
+        users: [],
+        voted: false,
+        consensus: { value: null, round: 0 },
+      }),
+    })
+    expect(screen.queryByText('Distribution')).not.toBeInTheDocument()
+    expect(screen.queryByText('Consensus')).not.toBeInTheDocument()
   })
 })

--- a/planningpoker-web/src/containers/__tests__/ResultsChart.test.jsx
+++ b/planningpoker-web/src/containers/__tests__/ResultsChart.test.jsx
@@ -15,6 +15,10 @@ vi.mock('react-chartjs-2', () => ({
 
 import ResultsChart from '../ResultsChart'
 import { renderWithStore } from '../../testUtils/renderWithStore'
+import { lightTheme } from '../../theme'
+
+const PRIMARY = lightTheme.palette.primary.main
+const BAR_MUTED = lightTheme.palette.chart.barMuted
 
 function state({ results = [], legalEstimates = ['1', '2', '3', '5', '8'] } = {}) {
   return {
@@ -25,6 +29,10 @@ function state({ results = [], legalEstimates = ['1', '2', '3', '5', '8'] } = {}
     notification: { error: null },
     rounds: [],
   }
+}
+
+function lastBarProps() {
+  return barSpy.mock.calls[barSpy.mock.calls.length - 1][0]
 }
 
 describe('ResultsChart container', () => {
@@ -48,94 +56,68 @@ describe('ResultsChart container', () => {
       }),
     })
 
-    const props = barSpy.mock.calls[barSpy.mock.calls.length - 1][0]
+    const props = lastBarProps()
     expect(props.data.labels).toEqual(['1', '2', '3', '5', '8'])
-    // The bar for "5" should have count 2
-    const values = props.data.datasets[0].data
-    expect(values[3]).toBe(2)
+    expect(props.data.datasets[0].data[3]).toBe(2)
   })
 
-  it('uses uniform default colors when no consensus is passed', () => {
+  it('uses the muted bar fill for every bar when no consensus is set', () => {
     renderWithStore(<ResultsChart />, { preloadedState: state() })
-    const ds = barSpy.mock.calls[barSpy.mock.calls.length - 1][0].data.datasets[0]
-    const unique = new Set(ds.backgroundColor)
-    expect(unique.size).toBe(1)
-    expect(ds.borderWidth.every((w) => w === 1)).toBe(true)
+    const ds = lastBarProps().data.datasets[0]
+    expect(new Set(ds.backgroundColor).size).toBe(1)
+    expect(ds.backgroundColor[0]).toBe(BAR_MUTED)
+    expect(ds.borderWidth.every((w) => w === 0)).toBe(true)
   })
 
-  it('highlights only the bar matching the consensus value', () => {
+  it('paints the consensus bar with primary and others muted', () => {
     renderWithStore(<ResultsChart consensus="5" />, { preloadedState: state() })
-    const ds = barSpy.mock.calls[barSpy.mock.calls.length - 1][0].data.datasets[0]
+    const ds = lastBarProps().data.datasets[0]
     // labels are ['1','2','3','5','8'] — index 3 is '5'
-    expect(ds.backgroundColor[3]).not.toBe(ds.backgroundColor[0])
-    expect(ds.borderWidth[3]).toBe(2)
-    expect(ds.borderWidth[0]).toBe(1)
-    // Only one bar is highlighted
-    const highlightedCount = ds.borderWidth.filter((w) => w === 2).length
-    expect(highlightedCount).toBe(1)
+    expect(ds.backgroundColor[3]).toBe(PRIMARY)
+    expect(ds.backgroundColor[0]).toBe(BAR_MUTED)
+    expect(ds.backgroundColor.filter((c) => c === PRIMARY)).toHaveLength(1)
+    // Border matches fill, no separate outline.
+    expect(ds.borderColor).toEqual(ds.backgroundColor)
   })
 
-  it('highlights the x-axis tick whenever consensus is set', () => {
-    // Case A: consensus value has zero votes
-    renderWithStore(<ResultsChart consensus="2" />, {
-      preloadedState: state({
-        results: [{ userName: 'alice', estimateValue: '5' }],
-      }),
-    })
-    let props = barSpy.mock.calls[barSpy.mock.calls.length - 1][0]
-    let tickColorFn = props.options.scales.x.ticks.color
-    let tickFontFn = props.options.scales.x.ticks.font
+  it('hides the underlying tick label for the consensus index so the pill renders cleanly', () => {
+    renderWithStore(<ResultsChart consensus="2" />, { preloadedState: state() })
+    const tickColorFn = lastBarProps().options.scales.x.ticks.color
     expect(typeof tickColorFn).toBe('function')
-    expect(tickColorFn({ index: 1 })).not.toBe(tickColorFn({ index: 0 }))
-    expect(tickFontFn({ index: 1 })).toEqual({ weight: 'bold' })
-    expect(tickFontFn({ index: 0 })).toEqual({})
-
-    cleanup()
-    barSpy.mockReset()
-
-    // Case B: consensus value has votes — tick still highlights
-    renderWithStore(<ResultsChart consensus="5" />, {
-      preloadedState: state({
-        results: [{ userName: 'alice', estimateValue: '5' }],
-      }),
-    })
-    props = barSpy.mock.calls[barSpy.mock.calls.length - 1][0]
-    tickColorFn = props.options.scales.x.ticks.color
-    tickFontFn = props.options.scales.x.ticks.font
-    // index 3 is '5'
-    expect(tickColorFn({ index: 3 })).not.toBe(tickColorFn({ index: 0 }))
-    expect(tickFontFn({ index: 3 })).toEqual({ weight: 'bold' })
+    // Index 1 is '2' (the consensus) → transparent; index 0 is '1' → secondary text color.
+    expect(tickColorFn({ index: 1 })).toBe('transparent')
+    expect(tickColorFn({ index: 0 })).not.toBe('transparent')
   })
 
-  it('does not highlight any x-axis tick when no consensus is set', () => {
+  it('does not hide any tick label when no consensus is set', () => {
     renderWithStore(<ResultsChart />, { preloadedState: state() })
-    const props = barSpy.mock.calls[barSpy.mock.calls.length - 1][0]
-    const tickColorFn = props.options.scales.x.ticks.color
-    const tickFontFn = props.options.scales.x.ticks.font
+    const tickColorFn = lastBarProps().options.scales.x.ticks.color
     const colors = [0, 1, 2, 3, 4].map((i) => tickColorFn({ index: i }))
     expect(new Set(colors).size).toBe(1)
-    ;[0, 1, 2, 3, 4].forEach((i) => expect(tickFontFn({ index: i })).toEqual({}))
+    expect(colors[0]).not.toBe('transparent')
   })
 
-  it('registers the axis-highlight plugin with current consensus options', () => {
+  it('registers the axis-pill plugin with current consensus options', () => {
     renderWithStore(<ResultsChart consensus="2" />, {
       preloadedState: state({
         results: [{ userName: 'alice', estimateValue: '5' }],
       }),
     })
-    const props = barSpy.mock.calls[barSpy.mock.calls.length - 1][0]
+    const props = lastBarProps()
     expect(Array.isArray(props.plugins)).toBe(true)
-    expect(props.plugins.some((p) => p.id === 'consensusAxisHighlight')).toBe(true)
-    expect(props.options.plugins.consensusAxisHighlight).toEqual({
+    expect(props.plugins.some((p) => p.id === 'consensusAxisPill')).toBe(true)
+    // Old plugin is gone.
+    expect(props.plugins.some((p) => p.id === 'consensusAxisHighlight')).toBe(false)
+    expect(props.options.plugins.consensusAxisPill).toEqual({
       consensus: '2',
       legalEstimates: ['1', '2', '3', '5', '8'],
-      aggregateData: [0, 0, 0, 1, 0],
+      pillBg: PRIMARY,
+      pillFg: '#fff',
     })
   })
 
-  it('passes null consensus to the axis-highlight plugin when none provided', () => {
+  it('passes null consensus to the axis-pill plugin when none provided', () => {
     renderWithStore(<ResultsChart />, { preloadedState: state() })
-    const props = barSpy.mock.calls[barSpy.mock.calls.length - 1][0]
-    expect(props.options.plugins.consensusAxisHighlight.consensus).toBeNull()
+    expect(lastBarProps().options.plugins.consensusAxisPill.consensus).toBeNull()
   })
 })

--- a/planningpoker-web/src/testUtils/renderWithStore.jsx
+++ b/planningpoker-web/src/testUtils/renderWithStore.jsx
@@ -1,7 +1,7 @@
 import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
 import { render } from '@testing-library/react'
-import { ThemeProvider, createTheme } from '@mui/material/styles'
+import { ThemeProvider } from '@mui/material/styles'
 
 import gameReducer from '../reducers/reducer_game'
 import resultsReducer from '../reducers/reducer_results'
@@ -10,8 +10,7 @@ import voteReducer from '../reducers/reducer_vote'
 import notificationReducer from '../reducers/reducer_notification'
 import roundsReducer from '../reducers/reducer_rounds'
 import consensusReducer from '../reducers/reducer_consensus'
-
-const theme = createTheme()
+import { lightTheme as theme } from '../theme'
 
 export function renderWithStore(ui, { preloadedState = {}, store, ...options } = {}) {
   const realStore =

--- a/planningpoker-web/src/theme.js
+++ b/planningpoker-web/src/theme.js
@@ -51,6 +51,9 @@ export const darkTheme = createTheme({
     divider: '#2e2e33',
     success: { main: '#22c55e' },
     error: { main: '#ef4444' },
+    chart: {
+      barMuted: 'rgba(102, 126, 234, 0.45)',
+    },
   },
   components: {
     ...shared.components,
@@ -85,6 +88,9 @@ export const lightTheme = createTheme({
     divider: '#e4e4e7',
     success: { main: '#16a34a' },
     error: { main: '#dc2626' },
+    chart: {
+      barMuted: '#c5cdf5',
+    },
   },
   components: {
     ...shared.components,


### PR DESCRIPTION
## Summary

Implements V8 from the Chart Consensus Highlight design handoff. Replaces the old opacity-based bar dimming and the zero-vote axis-tick ring with a single, consistent treatment that works the same whether or not anyone voted for the consensus value:

- **Header summary** above the chart: \`DISTRIBUTION\` eyebrow on the left; \`CONSENSUS X · N votes\` / \`· 1 vote\` / \`· no votes\` on the right.
- **Axis pill**: filled rounded-rect (\`primary.main\`) behind the consensus tick label, label re-drawn in white on top. Replaces the old \`consensusAxisHighlightPlugin\` ring (which only fired in the zero-vote case). Implemented as a Chart.js \`afterDraw\` plugin.
- **Bar colors**: consensus bar = \`primary.main\` full opacity; non-consensus bars = a new \`palette.chart.barMuted\` token (\`#c5cdf5\` light / \`rgba(102,126,234,0.45)\` dark) so the consensus bar has somewhere to pop against. Drops the previous opacity-based highlight, the per-bar borderColor/borderWidth distinction, and the per-tick \`xTickColor\`/\`xTickFont\` callbacks (the pill plugin overdraws the label).

The handoff also called for a tinted column band behind the consensus column; tried it, removed it on review — the band read as a phantom bar in the zero-vote case and felt like overkill in the general case. Axis pill + header copy already carry the signal.

\`renderWithStore\` test harness updated to use the real \`lightTheme\` so tests resolve the new \`palette.chart.barMuted\` token (the prior \`createTheme()\` default left it undefined).

## Test plan

- [x] \`npm test\` (Vitest, 223 tests)
- [x] \`npm run lint\` + \`npx prettier --check\`
- [x] \`npx playwright test\` (43 e2e)
- [x] \`./gradlew planningpoker-api:test spotlessCheck\`
- [x] Manual UAT in browser via Playwright MCP: light & dark themes × case A (consensus has votes) & case B (consensus has no votes) — header copy, pill placement, and bar colors all reactive when the host changes the consensus via the rail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)