### PR TITLE
refactor(web): DRY component-level duplication

### DIFF
--- a/planningpoker-web/src/containers/Results.jsx
+++ b/planningpoker-web/src/containers/Results.jsx
@@ -34,8 +34,7 @@ export default function Results() {
     : 0
 
   const handleNextItem = () => {
-    const consensus = consensusOverride || calcConsensus(results) || ''
-    dispatch(resetSession(playerName, sessionId, consensus))
+    dispatch(resetSession(playerName, sessionId, displayConsensus || ''))
   }
 
   const handleConsensusChange = (v) => {

--- a/planningpoker-web/src/pages/CreateGame.jsx
+++ b/planningpoker-web/src/pages/CreateGame.jsx
@@ -51,14 +51,10 @@ export default function CreateGame() {
 
   const isCustomValid = () => {
     if (schemeType !== 'custom') return true
-    const values = customValues
-      .split(',')
-      .map((v) => v.trim())
-      .filter((v) => v.length > 0)
-    const unique = [...new Set(values)]
-    if (unique.length < 2 || unique.length > 20) return false
-    if (unique.find((v) => v.length > 10)) return false
-    return true
+    const msg = validateCustomValues(customValues)
+    // 'Duplicate values removed' is informational — duplicates are deduped silently,
+    // so submission stays allowed (matches existing behaviour).
+    return msg === '' || msg === 'Duplicate values removed'
   }
 
   const handleSubmit = async (e) => {

--- a/planningpoker-web/src/reducers/reducer_game.js
+++ b/planningpoker-web/src/reducers/reducer_game.js
@@ -26,38 +26,34 @@ const initialGameState = {
   clientRound: 0,
 }
 
+function applySessionPayload(state, action) {
+  // sessionId comes from payload on CREATE_GAME (server-issued) and from meta on
+  // JOIN_GAME (client-supplied); everything else is identical between the two cases.
+  return {
+    ...state,
+    playerName: action.meta.userName,
+    sessionId: action.payload.sessionId ?? action.meta.sessionId,
+    legalEstimates: action.payload.values,
+    schemeType: action.payload.schemeType,
+    includeUnsure: action.payload.includeUnsure,
+    host: action.payload.host || '',
+    clientRound: action.payload.round ?? 0,
+    currentLabel: action.payload.label || '',
+  }
+}
+
 export default function (state = initialGameState, action) {
   switch (action.type) {
     case CREATE_GAME:
       if (action.error) return state
-      return {
-        ...state,
-        playerName: action.meta.userName,
-        sessionId: action.payload.sessionId,
-        legalEstimates: action.payload.values,
-        schemeType: action.payload.schemeType,
-        includeUnsure: action.payload.includeUnsure,
-        host: action.payload.host || '',
-        clientRound: action.payload.round ?? 0,
-        currentLabel: action.payload.label || '',
-      }
+      return applySessionPayload(state, action)
     case GAME_CREATED:
       return { ...state, isAdmin: true, isRegistered: true }
     case USER_REGISTERED:
       return { ...state, isRegistered: true }
     case JOIN_GAME:
       if (action.error) return state
-      return {
-        ...state,
-        playerName: action.meta.userName,
-        sessionId: action.meta.sessionId,
-        legalEstimates: action.payload.values,
-        schemeType: action.payload.schemeType,
-        includeUnsure: action.payload.includeUnsure,
-        host: action.payload.host || '',
-        clientRound: action.payload.round ?? 0,
-        currentLabel: action.payload.label || '',
-      }
+      return applySessionPayload(state, action)
     case USERS_UPDATED:
       return { ...state, host: action.payload.host || '' }
     case LABEL_UPDATED:


### PR DESCRIPTION
## Summary

Three small frontend DRY wins, each isolated to one file.

- **`pages/CreateGame.jsx`** — `isCustomValid()` now delegates to the existing `validateCustomValues()` helper instead of re-implementing the same parse + length/uniqueness checks. `'Duplicate values removed'` stays informational so submission behaviour is preserved.
- **`reducers/reducer_game.js`** — extract `applySessionPayload(state, action)` helper shared by `CREATE_GAME` and `JOIN_GAME`. The `sessionId` source difference (payload vs meta) is collapsed via `action.payload.sessionId ?? action.meta.sessionId`.
- **`containers/Results.jsx`** — `handleNextItem` now passes the already-computed `displayConsensus || ''` into `resetSession` instead of recomputing `consensusOverride || calcConsensus(results) || ''`.

No behaviour change. Existing 223 unit tests still pass.

## Test plan

- [x] `cd planningpoker-web && npm test -- --run` (223/223 pass)
- [x] `npm run lint` (clean)
- [x] `npm run format:check` (clean)
- [ ] CI: lint + build-web + unit-tests + e2e-tests + docker-build green