### PR TITLE
test(api): cleanup duplicates, extract backdateSession helper

### DIFF
--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/common/PlanningPokerTestFixture.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/common/PlanningPokerTestFixture.java
@@ -6,7 +6,6 @@ import java.util.List;
 
 public class PlanningPokerTestFixture {
   public static final String SESSION_ID = "abc12345";
-  public static final String ITEM = "A User Story";
   public static final String USER_NAME = "Rich";
   public static final String ESTIMATE_VALUE = "2";
   public static final Estimate ESTIMATE = new Estimate(USER_NAME, ESTIMATE_VALUE);

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/VoteControllerTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/VoteControllerTest.java
@@ -42,30 +42,6 @@ class VoteControllerTest extends AbstractControllerTest {
   }
 
   @Test
-  void testReVoteReplacesExistingEstimate() {
-    String newValue = "8";
-    Estimate newEstimate = new Estimate(USER_NAME, newValue);
-    when(sessionManager.isSessionActive(SESSION_ID)).thenReturn(true);
-    when(sessionManager.getSessionLegalValues(SESSION_ID)).thenReturn(STORY_POINT_VALUES);
-    when(sessionManager.getSessionUsers(SESSION_ID)).thenReturn(Lists.newArrayList(USER_NAME));
-    when(sessionManager.getRound(SESSION_ID)).thenReturn(1);
-    when(sessionManager.getResults(SESSION_ID)).thenReturn(List.of(newEstimate));
-
-    VoteResponse response = voteController.vote(SESSION_ID, USER_NAME, newValue);
-
-    assertEquals(1, response.round());
-    assertEquals(List.of(newEstimate), response.results());
-    inOrder.verify(sessionManager, times(1)).isSessionActive(SESSION_ID);
-    inOrder.verify(sessionManager, times(1)).getSessionLegalValues(SESSION_ID);
-    inOrder.verify(sessionManager, times(1)).getSessionUsers(SESSION_ID);
-    inOrder.verify(sessionManager, times(1)).registerEstimate(SESSION_ID, newEstimate);
-    inOrder.verify(sessionManager, times(1)).getRound(SESSION_ID);
-    inOrder.verify(sessionManager, times(1)).getResults(SESSION_ID);
-    inOrder.verify(messagingUtils, times(1)).sendResultsMessage(SESSION_ID);
-    inOrder.verifyNoMoreInteractions();
-  }
-
-  @Test
   void testVoteInvalidSession() {
     when(sessionManager.isSessionActive(SESSION_ID)).thenReturn(false);
     assertThrows(

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/service/SessionManagerTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/service/SessionManagerTest.java
@@ -8,6 +8,7 @@ import com.richashworth.planningpoker.model.Round;
 import com.richashworth.planningpoker.model.SchemeConfig;
 import com.richashworth.planningpoker.model.SchemeType;
 import java.lang.reflect.Field;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -33,6 +34,25 @@ class SessionManagerTest {
   /** Default-scheme session helper — replaces the now-removed no-arg createSession overload. */
   private String createSession() {
     return sessionManager.createSession(new SchemeConfig("fibonacci", null, true));
+  }
+
+  /**
+   * Backdates the {@code lastActivity} entry for {@code sessionId} so {@code evictIdleSessions}
+   * will sweep it. Replaces eight copies of the same reflection boilerplate.
+   */
+  private void backdateSession(String sessionId, Duration age) throws Exception {
+    lastActivityMap().put(sessionId, Instant.now().minus(age));
+  }
+
+  /**
+   * Returns the inner {@code lastActivity} map via reflection — used by {@link #backdateSession}
+   * and by the one test that asserts on map cleanup directly.
+   */
+  @SuppressWarnings("unchecked")
+  private ConcurrentHashMap<String, Instant> lastActivityMap() throws Exception {
+    Field lastActivityField = SessionManager.class.getDeclaredField("lastActivity");
+    lastActivityField.setAccessible(true);
+    return (ConcurrentHashMap<String, Instant>) lastActivityField.get(sessionManager);
   }
 
   @Test
@@ -198,13 +218,7 @@ class SessionManagerTest {
     sessionManager.registerUser("Bob", idleSession);
     sessionManager.registerEstimate(idleSession, new Estimate("Bob", "3"));
 
-    // Use reflection to backdate the idle session's lastActivity to 25 hours ago
-    Field lastActivityField = SessionManager.class.getDeclaredField("lastActivity");
-    lastActivityField.setAccessible(true);
-    @SuppressWarnings("unchecked")
-    ConcurrentHashMap<String, Instant> lastActivity =
-        (ConcurrentHashMap<String, Instant>) lastActivityField.get(sessionManager);
-    lastActivity.put(idleSession, Instant.now().minusSeconds(25 * 60 * 60));
+    backdateSession(idleSession, Duration.ofHours(25));
 
     sessionManager.evictIdleSessions();
 
@@ -217,25 +231,19 @@ class SessionManagerTest {
   }
 
   @Test
-  void testEvictIdleSessionsClearsAllSevenMaps() throws Exception {
+  void testEvictIdleSessionsClearsAllSessionMaps() throws Exception {
     String sessionId = sessionManager.createSession(new SchemeConfig("fibonacci", null, true));
     sessionManager.registerUser("Alice", sessionId);
     sessionManager.registerEstimate(sessionId, new Estimate("Alice", "5"));
 
-    // Backdate lastActivity to 25 hours ago
-    Field lastActivityField = SessionManager.class.getDeclaredField("lastActivity");
-    lastActivityField.setAccessible(true);
-    @SuppressWarnings("unchecked")
-    ConcurrentHashMap<String, Instant> lastActivity =
-        (ConcurrentHashMap<String, Instant>) lastActivityField.get(sessionManager);
-    lastActivity.put(sessionId, Instant.now().minusSeconds(25 * 60 * 60));
+    backdateSession(sessionId, Duration.ofHours(25));
 
     sessionManager.evictIdleSessions();
 
     assertFalse(sessionManager.isSessionActive(sessionId));
     assertTrue(sessionManager.getResults(sessionId).isEmpty());
     assertTrue(sessionManager.getSessionUsers(sessionId).isEmpty());
-    assertFalse(lastActivity.containsKey(sessionId));
+    assertFalse(lastActivityMap().containsKey(sessionId));
     assertTrue(sessionManager.getSessionLegalValues(sessionId).isEmpty());
     assertNull(sessionManager.getSessionSchemeConfig(sessionId));
     assertNull(sessionManager.getHost(sessionId));
@@ -262,12 +270,7 @@ class SessionManagerTest {
     String idleSession = createSession();
     sessionManager.registerUser("Bob", idleSession);
 
-    Field lastActivityField = SessionManager.class.getDeclaredField("lastActivity");
-    lastActivityField.setAccessible(true);
-    @SuppressWarnings("unchecked")
-    ConcurrentHashMap<String, Instant> lastActivity =
-        (ConcurrentHashMap<String, Instant>) lastActivityField.get(sessionManager);
-    lastActivity.put(idleSession, Instant.now().minusSeconds(25 * 60 * 60));
+    backdateSession(idleSession, Duration.ofHours(25));
 
     sessionManager.evictIdleSessions();
 
@@ -340,13 +343,7 @@ class SessionManagerTest {
     String activeSession = sessionManager.createSession(new SchemeConfig("fibonacci", null, true));
     String idleSession = sessionManager.createSession(new SchemeConfig("tshirt", null, false));
 
-    // Backdate lastActivity for idle session
-    Field lastActivityField = SessionManager.class.getDeclaredField("lastActivity");
-    lastActivityField.setAccessible(true);
-    @SuppressWarnings("unchecked")
-    ConcurrentHashMap<String, Instant> lastActivity =
-        (ConcurrentHashMap<String, Instant>) lastActivityField.get(sessionManager);
-    lastActivity.put(idleSession, Instant.now().minusSeconds(25 * 60 * 60));
+    backdateSession(idleSession, Duration.ofHours(25));
 
     sessionManager.evictIdleSessions();
 
@@ -413,13 +410,7 @@ class SessionManagerTest {
     String idleSession = createSession();
     sessionManager.registerUser("Bob", idleSession);
 
-    // Backdate lastActivity for idle session
-    Field lastActivityField = SessionManager.class.getDeclaredField("lastActivity");
-    lastActivityField.setAccessible(true);
-    @SuppressWarnings("unchecked")
-    ConcurrentHashMap<String, Instant> lastActivity =
-        (ConcurrentHashMap<String, Instant>) lastActivityField.get(sessionManager);
-    lastActivity.put(idleSession, Instant.now().minusSeconds(25 * 60 * 60));
+    backdateSession(idleSession, Duration.ofHours(25));
 
     sessionManager.evictIdleSessions();
 
@@ -539,15 +530,9 @@ class SessionManagerTest {
     }
 
     // Backdate the first 5 sessions to be idle (25 hours ago)
-    Field lastActivityField = SessionManager.class.getDeclaredField("lastActivity");
-    lastActivityField.setAccessible(true);
-    @SuppressWarnings("unchecked")
-    ConcurrentHashMap<String, Instant> lastActivity =
-        (ConcurrentHashMap<String, Instant>) lastActivityField.get(sessionManager);
-
     for (int i = 0; i < 5; i++) {
       String idleSessionId = allSessions.get(i);
-      lastActivity.put(idleSessionId, Instant.now().minusSeconds(25 * 60 * 60));
+      backdateSession(idleSessionId, Duration.ofHours(25));
       idleSessions.add(idleSessionId);
     }
 
@@ -725,12 +710,7 @@ class SessionManagerTest {
     String idleSession = createSession();
     sessionManager.setConsensusOverride(idleSession, "5");
 
-    Field lastActivityField = SessionManager.class.getDeclaredField("lastActivity");
-    lastActivityField.setAccessible(true);
-    @SuppressWarnings("unchecked")
-    ConcurrentHashMap<String, Instant> lastActivity =
-        (ConcurrentHashMap<String, Instant>) lastActivityField.get(sessionManager);
-    lastActivity.put(idleSession, Instant.now().minusSeconds(25 * 60 * 60));
+    backdateSession(idleSession, Duration.ofHours(25));
 
     sessionManager.evictIdleSessions();
     assertNull(sessionManager.getConsensusOverride(idleSession));
@@ -743,12 +723,7 @@ class SessionManagerTest {
     sessionManager.incrementAndGetRound(idleSession);
     sessionManager.incrementAndGetRound(idleSession);
 
-    Field lastActivityField = SessionManager.class.getDeclaredField("lastActivity");
-    lastActivityField.setAccessible(true);
-    @SuppressWarnings("unchecked")
-    ConcurrentHashMap<String, Instant> lastActivity =
-        (ConcurrentHashMap<String, Instant>) lastActivityField.get(sessionManager);
-    lastActivity.put(idleSession, Instant.now().minusSeconds(25 * 60 * 60));
+    backdateSession(idleSession, Duration.ofHours(25));
 
     sessionManager.evictIdleSessions();
     assertEquals(0, sessionManager.getRound(idleSession));

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/util/MessagingUtilsTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/util/MessagingUtilsTest.java
@@ -65,19 +65,6 @@ class MessagingUtilsTest {
   }
 
   @Test
-  void testSendUsersMessageIncludesHost() {
-    when(sessionManager.getSessionUsers(SESSION_ID)).thenReturn(USERS);
-    when(sessionManager.getHost(SESSION_ID)).thenReturn("HostUser");
-    messagingUtils.sendUsersMessage(SESSION_ID);
-    ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
-    verify(template).convertAndSend(eq(getTopic(TOPIC_USERS, SESSION_ID)), captor.capture());
-    Map<String, Object> expectedPayload = new LinkedHashMap<>();
-    expectedPayload.put("users", USERS);
-    expectedPayload.put("host", "HostUser");
-    assertEquals(messagingUtils.usersMessage(expectedPayload), captor.getValue());
-  }
-
-  @Test
   void testSendUsersMessageWithNullHost() {
     when(sessionManager.getSessionUsers(SESSION_ID)).thenReturn(USERS);
     when(sessionManager.getHost(SESSION_ID)).thenReturn(null);
@@ -116,17 +103,6 @@ class MessagingUtilsTest {
     org.junit.jupiter.api.Assertions.assertTrue(str.contains("USER_LEFT_MESSAGE"), str);
     org.junit.jupiter.api.Assertions.assertTrue(str.contains("round=2"), str);
     org.junit.jupiter.api.Assertions.assertTrue(str.contains("leaver=Alice"), str);
-  }
-
-  @Test
-  void testSendResultsMessageEmitsExactlyOnce() {
-    when(sessionManager.getRound(SESSION_ID)).thenReturn(1);
-    when(sessionManager.getResults(SESSION_ID)).thenReturn(List.of());
-    when(sessionManager.getLabel(SESSION_ID)).thenReturn("");
-    messagingUtils.sendResultsMessage(SESSION_ID);
-    verify(template, times(1))
-        .convertAndSend(eq(getTopic(TOPIC_RESULTS, SESSION_ID)), (Object) any());
-    verifyNoMoreInteractions(template);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Five small test-cleanup wins in `planningpoker-api/src/test`:

- **`SessionManagerTest`** — extract a `backdateSession(sessionId, Duration)` helper (plus a one-line `lastActivityMap()` accessor) that replaces eight copies of the same `Field`/`setAccessible`/`ConcurrentHashMap` reflection block. Tests are now one-liners: `backdateSession(id, Duration.ofHours(25))`.
- **`SessionManagerTest`** — rename `testEvictIdleSessionsClearsAllSevenMaps` → `testEvictIdleSessionsClearsAllSessionMaps`. The map count grew to eleven after consensus + completed-rounds were added; dropping the count from the name prevents future drift.
- **`MessagingUtilsTest`** — collapse `testSendUsersMessage` + `testSendUsersMessageIncludesHost` (same payload, two mocking styles). Drop `testSendResultsMessageEmitsExactlyOnce` (subsumed by `testSendResultsMessageIncludesRound`, which already verifies `times(1)` + `verifyNoMoreInteractions`).
- **`VoteControllerTest`** — drop `testReVoteReplacesExistingEstimate`: same mocked path as `testVote`. The upsert semantic is covered at the right layer in `SessionManagerTest#testRegisterEstimateReplacesExistingForSameUser`.
- **`PlanningPokerTestFixture`** — delete unused `ITEM = "A User Story"` constant (zero callers across the test tree).

Net diff: +30 / −104 across 4 files.

> **Note:** This branch is stacked on top of #162 (refactor/api-remove-dead-code). The diff against `master` will include #162's commit until that PR merges, after which this PR will show only the 4 test-cleanup files. Sequencing matters because both PRs touch `SessionManagerTest.java`.

## Test plan

- [x] `./gradlew planningpoker-api:test` — all tests pass after dedupe (count drops as expected: −2 in MessagingUtilsTest, −1 in VoteControllerTest)
- [x] `./gradlew spotlessCheck` — clean
- [x] Verified `ITEM` had no remaining references via `grep -rn ITEM`

🤖 Generated with [Claude Code](https://claude.com/claude-code)