### PR TITLE
test(web): missing thunk coverage + Vote ordering + e2e dedupe

### DIFF
--- a/planningpoker-web/src/actions/__tests__/index.test.js
+++ b/planningpoker-web/src/actions/__tests__/index.test.js
@@ -7,13 +7,18 @@ import {
   voteOptimistic,
   createGame,
   joinGame,
+  leaveGame,
   vote,
   resetSession,
   refresh,
+  kickUser,
+  promoteUser,
+  setLabel,
   setConsensusOverride,
   consensusOverrideUpdated,
   CREATE_GAME,
   JOIN_GAME,
+  LEAVE_GAME,
   VOTE,
   VOTE_OPTIMISTIC,
   RESET_SESSION,
@@ -21,6 +26,9 @@ import {
   LABEL_UPDATED,
   USERS_UPDATED,
   ROUNDS_REPLACE,
+  KICK_USER,
+  PROMOTE_USER,
+  SET_LABEL,
   SET_CONSENSUS_OVERRIDE,
   CONSENSUS_OVERRIDE_UPDATED,
   CONSENSUS_OVERRIDE_LOCAL,
@@ -312,5 +320,152 @@ describe('setConsensusOverride', () => {
     expect(action.error).toBe(true)
     const errorAction = dispatched.find((a) => a.type === 'show-error')
     expect(errorAction.payload).toBe('only the host can perform this action')
+  })
+})
+
+describe('kickUser', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('POSTs userName/targetUser/sessionId and dispatches KICK_USER on success', async () => {
+    axios.post = vi.fn().mockResolvedValue({ data: { ok: true } })
+
+    const dispatched = await runThunkAsync(kickUser('alice', 'bob', 'abc12345'))
+
+    expect(dispatched).toHaveLength(1)
+    expect(dispatched[0].type).toBe(KICK_USER)
+    expect(dispatched[0].payload).toEqual({ ok: true })
+    expect(dispatched[0].error).toBeFalsy()
+
+    const [, params] = axios.post.mock.calls[0]
+    expect(params.get('userName')).toBe('alice')
+    expect(params.get('targetUser')).toBe('bob')
+    expect(params.get('sessionId')).toBe('abc12345')
+  })
+
+  it('dispatches KICK_USER with error:true and show-error on failure', async () => {
+    axios.post = vi.fn().mockRejectedValue({
+      response: { data: { error: 'only the host can perform this action' } },
+    })
+
+    const dispatched = await runThunkAsync(kickUser('mallory', 'bob', 'abc12345'))
+
+    expect(dispatched).toHaveLength(2)
+    const errAction = dispatched.find((a) => a.type === KICK_USER)
+    expect(errAction).toBeDefined()
+    expect(errAction.error).toBe(true)
+    expect(dispatched.find((a) => a.type === 'show-error').payload).toBe(
+      'only the host can perform this action',
+    )
+  })
+})
+
+describe('promoteUser', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('POSTs userName/targetUser/sessionId and dispatches PROMOTE_USER on success', async () => {
+    axios.post = vi.fn().mockResolvedValue({ data: { newHost: 'bob' } })
+
+    const dispatched = await runThunkAsync(promoteUser('alice', 'bob', 'abc12345'))
+
+    expect(dispatched).toHaveLength(1)
+    expect(dispatched[0].type).toBe(PROMOTE_USER)
+    expect(dispatched[0].payload).toEqual({ newHost: 'bob' })
+    expect(dispatched[0].error).toBeFalsy()
+
+    const [, params] = axios.post.mock.calls[0]
+    expect(params.get('userName')).toBe('alice')
+    expect(params.get('targetUser')).toBe('bob')
+    expect(params.get('sessionId')).toBe('abc12345')
+  })
+
+  it('dispatches PROMOTE_USER with error:true and show-error on failure', async () => {
+    axios.post = vi.fn().mockRejectedValue({
+      response: { data: { error: 'target not in session' } },
+    })
+
+    const dispatched = await runThunkAsync(promoteUser('alice', 'ghost', 'abc12345'))
+
+    const errAction = dispatched.find((a) => a.type === PROMOTE_USER)
+    expect(errAction.error).toBe(true)
+    expect(dispatched.find((a) => a.type === 'show-error').payload).toBe('target not in session')
+  })
+})
+
+describe('setLabel', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('POSTs userName/sessionId/label and dispatches a bare SET_LABEL on success', async () => {
+    axios.post = vi.fn().mockResolvedValue({ data: {} })
+
+    const dispatched = await runThunkAsync(setLabel('alice', 'abc12345', 'Sprint 1'))
+
+    // Helper's omitSuccessPayload path: type only, no payload/meta.
+    expect(dispatched).toHaveLength(1)
+    expect(dispatched[0]).toEqual({ type: SET_LABEL })
+
+    const [, params] = axios.post.mock.calls[0]
+    expect(params.get('userName')).toBe('alice')
+    expect(params.get('sessionId')).toBe('abc12345')
+    expect(params.get('label')).toBe('Sprint 1')
+  })
+
+  it('dispatches SET_LABEL with error:true and show-error on failure', async () => {
+    axios.post = vi.fn().mockRejectedValue({
+      response: { data: { error: 'only the host can perform this action' } },
+    })
+
+    const dispatched = await runThunkAsync(setLabel('mallory', 'abc12345', 'x'))
+
+    const errAction = dispatched.find((a) => a.type === SET_LABEL)
+    expect(errAction.error).toBe(true)
+    expect(dispatched.find((a) => a.type === 'show-error').payload).toBe(
+      'only the host can perform this action',
+    )
+  })
+})
+
+describe('leaveGame', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('dispatches LEAVE_GAME first, POSTs /logout, then calls onSuccess', async () => {
+    axios.post = vi.fn().mockResolvedValue({ data: {} })
+    const onSuccess = vi.fn()
+
+    const dispatched = await runThunkAsync(leaveGame('alice', 'abc12345', onSuccess))
+
+    // LEAVE_GAME is dispatched eagerly so the broadcast that follows logout
+    // can't trip PlayGame's kick-detection effect.
+    expect(dispatched[0]).toEqual({ type: LEAVE_GAME })
+
+    const [url, params] = axios.post.mock.calls[0]
+    expect(url).toMatch(/\/logout$/)
+    expect(params.get('userName')).toBe('alice')
+    expect(params.get('sessionId')).toBe('abc12345')
+
+    expect(onSuccess).toHaveBeenCalledOnce()
+  })
+
+  it('still calls onSuccess when /logout fails (failure is logged, not dispatched)', async () => {
+    axios.post = vi.fn().mockRejectedValue(new Error('boom'))
+    const onSuccess = vi.fn()
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const dispatched = await runThunkAsync(leaveGame('alice', 'abc12345', onSuccess))
+
+    expect(dispatched[0]).toEqual({ type: LEAVE_GAME })
+    // No additional error dispatch — leaveGame logs and returns silently.
+    expect(dispatched).toHaveLength(1)
+    expect(onSuccess).toHaveBeenCalledOnce()
+    expect(consoleSpy).toHaveBeenCalled()
+
+    consoleSpy.mockRestore()
   })
 })

--- a/planningpoker-web/src/actions/index.js
+++ b/planningpoker-web/src/actions/index.js
@@ -74,22 +74,69 @@ export const consensusOverrideLocal = (value) => ({
 
 export const kicked = () => ({ type: KICKED })
 
+// Shared POST + dispatch helper. Wraps the axios call, dispatches a typed
+// success or error action, and routes the server's error message (or a
+// fallback) through showError. Each thunk that posts to a mutation endpoint
+// flows through here so the success/error envelope shape stays consistent.
+//
+// Options:
+//   url                - path appended to API_ROOT_URL
+//   params             - object encoded as URLSearchParams (form POST). Used
+//                        when `body` is omitted.
+//   body               - raw request body sent as-is (for JSON endpoints).
+//   type               - action type dispatched on both success and failure.
+//   meta               - meta object included on the dispatched action.
+//   fallbackError      - showError message when the server didn't supply one.
+//   omitSuccessPayload - dispatch `{ type }` only on success (no payload/meta).
+//                        Matches existing thunks that don't carry success data.
+//   onSuccess          - called after the success dispatch, with response data.
+//   onError            - called before the standard error dispatches, with the
+//                        caught error. Lets a thunk run revert logic before the
+//                        error/showError actions fire (preserves dispatch order).
+async function postForm(dispatch, opts) {
+  const {
+    url,
+    params,
+    body,
+    type,
+    meta,
+    fallbackError,
+    omitSuccessPayload = false,
+    onSuccess,
+    onError,
+  } = opts
+  const metaPart = meta ? { meta } : {}
+  try {
+    const requestBody = body !== undefined ? body : new URLSearchParams(params)
+    const { data } = await axios.post(`${API_ROOT_URL}${url}`, requestBody)
+    dispatch(omitSuccessPayload ? { type } : { type, payload: data, ...metaPart })
+    if (onSuccess) onSuccess(data)
+    return { data, error: null }
+  } catch (err) {
+    if (onError) onError(err)
+    dispatch({ type, payload: err, error: true, ...metaPart })
+    dispatch(showError(err.response?.data?.error || fallbackError))
+    return { data: null, error: err }
+  }
+}
+
 export function createGame(playerName, schemeOptions, onSuccess) {
   return async (dispatch) => {
-    try {
-      const body = {
+    await postForm(dispatch, {
+      url: '/createSession',
+      body: {
         userName: playerName,
         schemeType: schemeOptions.schemeType,
         customValues: schemeOptions.customValues,
         includeUnsure: schemeOptions.includeUnsure,
-      }
-      const { data } = await axios.post(`${API_ROOT_URL}/createSession`, body)
-      dispatch({ type: CREATE_GAME, payload: data, meta: { userName: playerName } })
-      if (onSuccess) onSuccess()
-    } catch (err) {
-      dispatch({ type: CREATE_GAME, payload: err, error: true, meta: { userName: playerName } })
-      dispatch(showError(err.response?.data?.error || 'Failed to create session'))
-    }
+      },
+      type: CREATE_GAME,
+      meta: { userName: playerName },
+      fallbackError: 'Failed to create session',
+      onSuccess: () => {
+        if (onSuccess) onSuccess()
+      },
+    })
   }
 }
 
@@ -112,86 +159,63 @@ export function leaveGame(playerName, sessionId, onSuccess) {
 
 export function joinGame(playerName, sessionId, onSuccess) {
   return async (dispatch) => {
-    try {
-      const { data } = await axios.post(
-        `${API_ROOT_URL}/joinSession`,
-        new URLSearchParams({ userName: playerName, sessionId }),
-      )
-      dispatch({ type: JOIN_GAME, payload: data, meta: { userName: playerName, sessionId } })
-      if (onSuccess) onSuccess()
-    } catch (err) {
-      dispatch({
-        type: JOIN_GAME,
-        payload: err,
-        error: true,
-        meta: { userName: playerName, sessionId },
-      })
-      dispatch(showError(err.response?.data?.error || 'Failed to join session'))
-    }
+    await postForm(dispatch, {
+      url: '/joinSession',
+      params: { userName: playerName, sessionId },
+      type: JOIN_GAME,
+      meta: { userName: playerName, sessionId },
+      fallbackError: 'Failed to join session',
+      onSuccess: () => {
+        if (onSuccess) onSuccess()
+      },
+    })
   }
 }
 
 export function vote(playerName, sessionId, estimateValue) {
   return async (dispatch) => {
-    try {
-      const { data } = await axios.post(
-        `${API_ROOT_URL}/vote`,
-        new URLSearchParams({ userName: playerName, sessionId, estimateValue }),
-      )
-      dispatch({ type: VOTE, payload: data, meta: { userName: playerName, estimateValue } })
-    } catch (err) {
-      dispatch({
-        type: VOTE,
-        payload: err,
-        error: true,
-        meta: { userName: playerName, estimateValue },
-      })
-      dispatch(showError(err.response?.data?.error || 'Failed to submit vote'))
-    }
+    await postForm(dispatch, {
+      url: '/vote',
+      params: { userName: playerName, sessionId, estimateValue },
+      type: VOTE,
+      meta: { userName: playerName, estimateValue },
+      fallbackError: 'Failed to submit vote',
+    })
   }
 }
 
 export function resetSession(playerName, sessionId, consensus) {
   return async (dispatch) => {
-    try {
-      const params = { sessionId, userName: playerName }
-      if (consensus != null && consensus !== '') params.consensus = consensus
-      const { data } = await axios.post(`${API_ROOT_URL}/reset`, new URLSearchParams(params))
-      dispatch({ type: RESET_SESSION, payload: data })
-    } catch (err) {
-      dispatch({ type: RESET_SESSION, payload: err, error: true })
-      dispatch(showError(err.response?.data?.error || 'Failed to reset session'))
-    }
+    const params = { sessionId, userName: playerName }
+    if (consensus != null && consensus !== '') params.consensus = consensus
+    await postForm(dispatch, {
+      url: '/reset',
+      params,
+      type: RESET_SESSION,
+      fallbackError: 'Failed to reset session',
+    })
   }
 }
 
 export function kickUser(userName, targetUser, sessionId) {
   return async (dispatch) => {
-    try {
-      const { data } = await axios.post(
-        `${API_ROOT_URL}/kick`,
-        new URLSearchParams({ userName, targetUser, sessionId }),
-      )
-      dispatch({ type: KICK_USER, payload: data })
-    } catch (err) {
-      dispatch({ type: KICK_USER, payload: err, error: true })
-      dispatch(showError(err.response?.data?.error || 'Failed to kick user'))
-    }
+    await postForm(dispatch, {
+      url: '/kick',
+      params: { userName, targetUser, sessionId },
+      type: KICK_USER,
+      fallbackError: 'Failed to kick user',
+    })
   }
 }
 
 export function promoteUser(userName, targetUser, sessionId) {
   return async (dispatch) => {
-    try {
-      const { data } = await axios.post(
-        `${API_ROOT_URL}/promote`,
-        new URLSearchParams({ userName, targetUser, sessionId }),
-      )
-      dispatch({ type: PROMOTE_USER, payload: data })
-    } catch (err) {
-      dispatch({ type: PROMOTE_USER, payload: err, error: true })
-      dispatch(showError(err.response?.data?.error || 'Failed to promote user'))
-    }
+    await postForm(dispatch, {
+      url: '/promote',
+      params: { userName, targetUser, sessionId },
+      type: PROMOTE_USER,
+      fallbackError: 'Failed to promote user',
+    })
   }
 }
 
@@ -213,16 +237,13 @@ export function refresh(sessionId, playerName) {
 
 export function setLabel(userName, sessionId, label) {
   return async (dispatch) => {
-    try {
-      await axios.post(
-        `${API_ROOT_URL}/setLabel`,
-        new URLSearchParams({ userName, sessionId, label }),
-      )
-      dispatch({ type: SET_LABEL })
-    } catch (err) {
-      dispatch({ type: SET_LABEL, payload: err, error: true })
-      dispatch(showError(err.response?.data?.error || 'Failed to set label'))
-    }
+    await postForm(dispatch, {
+      url: '/setLabel',
+      params: { userName, sessionId, label },
+      type: SET_LABEL,
+      fallbackError: 'Failed to set label',
+      omitSuccessPayload: true,
+    })
   }
 }
 
@@ -230,18 +251,18 @@ export function setConsensusOverride(userName, sessionId, value) {
   return async (dispatch, getState) => {
     // Optimistically update the value so the click feels instant; the server's
     // broadcast (with a strictly newer round) is the authoritative reconciler.
-    // On POST failure we revert to the prior value.
+    // On POST failure we revert to the prior value before the error dispatches.
     const prior = getState().consensus?.value ?? null
     dispatch(consensusOverrideLocal(value))
-    try {
-      const params = { userName, sessionId }
-      if (value != null && value !== '') params.value = value
-      await axios.post(`${API_ROOT_URL}/setConsensus`, new URLSearchParams(params))
-      dispatch({ type: SET_CONSENSUS_OVERRIDE })
-    } catch (err) {
-      dispatch(consensusOverrideLocal(prior))
-      dispatch({ type: SET_CONSENSUS_OVERRIDE, payload: err, error: true })
-      dispatch(showError(err.response?.data?.error || 'Failed to set consensus'))
-    }
+    const params = { userName, sessionId }
+    if (value != null && value !== '') params.value = value
+    await postForm(dispatch, {
+      url: '/setConsensus',
+      params,
+      type: SET_CONSENSUS_OVERRIDE,
+      fallbackError: 'Failed to set consensus',
+      omitSuccessPayload: true,
+      onError: () => dispatch(consensusOverrideLocal(prior)),
+    })
   }
 }

--- a/planningpoker-web/src/components/NameInput.jsx
+++ b/planningpoker-web/src/components/NameInput.jsx
@@ -1,4 +1,5 @@
 import TextField from '@mui/material/TextField'
+import { USERNAME_PATTERN } from '../config/Constants'
 
 export default function NameInput({ playerName, onPlayerNameInputChange }) {
   return (
@@ -11,7 +12,7 @@ export default function NameInput({ playerName, onPlayerNameInputChange }) {
       fullWidth
       slotProps={{
         htmlInput: {
-          pattern: '[a-zA-Z0-9 _\\-]{3,20}',
+          pattern: USERNAME_PATTERN,
           title: 'Name must be 3-20 characters: letters, numbers, spaces, hyphens, or underscores',
         },
       }}

--- a/planningpoker-web/src/config/Constants.js
+++ b/planningpoker-web/src/config/Constants.js
@@ -1,5 +1,11 @@
 export const API_ROOT_URL = ''
 
+// Username constraint shared by NameInput's HTML pattern attribute and the
+// JS-side guard in CreateGame/JoinGame. 3-20 chars: letters, digits, spaces,
+// hyphens, underscores. The anchored RegExp is derived from the same source.
+export const USERNAME_PATTERN = '[a-zA-Z0-9 _-]{3,20}'
+export const USERNAME_REGEX = new RegExp(`^${USERNAME_PATTERN}$`)
+
 export const SCHEME_VALUES = {
   fibonacci: ['1', '2', '3', '5', '8', '13'],
   tshirt: ['XS', 'S', 'M', 'L', 'XL', 'XXL'],

--- a/planningpoker-web/src/containers/__tests__/Vote.test.jsx
+++ b/planningpoker-web/src/containers/__tests__/Vote.test.jsx
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { screen, fireEvent, act, cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
+import { configureStore } from '@reduxjs/toolkit'
 
 vi.mock('axios', () => ({
   default: {
@@ -13,6 +14,28 @@ vi.mock('axios', () => ({
 import axios from 'axios'
 import Vote from '../Vote'
 import { renderWithStore } from '../../testUtils/renderWithStore'
+import gameReducer from '../../reducers/reducer_game'
+import resultsReducer from '../../reducers/reducer_results'
+import usersReducer from '../../reducers/reducer_users'
+import voteReducer from '../../reducers/reducer_vote'
+import notificationReducer from '../../reducers/reducer_notification'
+import roundsReducer from '../../reducers/reducer_rounds'
+import consensusReducer from '../../reducers/reducer_consensus'
+
+function buildStore(preloadedState) {
+  return configureStore({
+    reducer: {
+      game: gameReducer,
+      results: resultsReducer,
+      users: usersReducer,
+      voted: voteReducer,
+      notification: notificationReducer,
+      rounds: roundsReducer,
+      consensus: consensusReducer,
+    },
+    preloadedState,
+  })
+}
 
 function baseState(overrides = {}) {
   return {
@@ -91,5 +114,33 @@ describe('Vote container', () => {
     })
 
     expect(axios.post).toHaveBeenCalledWith(expect.stringMatching(/\/vote$/), expect.anything())
+  })
+
+  it('dispatches voteOptimistic synchronously before the vote thunk', async () => {
+    // Pre-spy on dispatch so Vote's first render captures the spy via
+    // useDispatch (which reads store.dispatch each render, and the component
+    // holds the captured reference for subsequent event handlers).
+    const store = buildStore(baseState())
+    const dispatchSpy = vi.spyOn(store, 'dispatch')
+    renderWithStore(<Vote />, { store })
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Vote 5'))
+    })
+
+    // doVote fires `voteOptimistic` (plain action) and then `vote` (thunk fn)
+    // through the same dispatch. The spy records both top-level calls;
+    // confirm the optimistic action lands before the thunk.
+    const calls = dispatchSpy.mock.calls.map(([arg]) => arg)
+    const optimisticIdx = calls.findIndex(
+      (a) => a && typeof a === 'object' && a.type === 'vote-optimistic',
+    )
+    const thunkIdx = calls.findIndex((a) => typeof a === 'function')
+
+    expect(optimisticIdx).toBeGreaterThanOrEqual(0)
+    expect(thunkIdx).toBeGreaterThan(optimisticIdx)
+    expect(calls[optimisticIdx].payload).toEqual({ userName: 'alice', estimateValue: '5' })
+
+    dispatchSpy.mockRestore()
   })
 })

--- a/planningpoker-web/src/pages/CreateGame.jsx
+++ b/planningpoker-web/src/pages/CreateGame.jsx
@@ -13,7 +13,7 @@ import CircularProgress from '@mui/material/CircularProgress'
 import { createGame, gameCreated } from '../actions'
 import NameInput from '../components/NameInput'
 import SchemeTile from '../components/SchemeTile'
-import { SCHEME_VALUES, SCHEME_METADATA, SCHEME_ORDER } from '../config/Constants'
+import { SCHEME_VALUES, SCHEME_METADATA, SCHEME_ORDER, USERNAME_REGEX } from '../config/Constants'
 
 function validateCustomValues(input) {
   const values = input
@@ -64,8 +64,7 @@ export default function CreateGame() {
   const handleSubmit = async (e) => {
     e.preventDefault()
     if (submitting) return
-    const nameRegex = /^[a-zA-Z0-9 _-]{3,20}$/
-    if (!nameRegex.test(playerName)) return
+    if (!USERNAME_REGEX.test(playerName)) return
     if (!isCustomValid()) return
     setSubmitting(true)
     try {

--- a/planningpoker-web/src/pages/JoinGame.jsx
+++ b/planningpoker-web/src/pages/JoinGame.jsx
@@ -10,6 +10,7 @@ import Button from '@mui/material/Button'
 import CircularProgress from '@mui/material/CircularProgress'
 import { joinGame, userRegistered } from '../actions'
 import NameInput from '../components/NameInput'
+import { USERNAME_REGEX } from '../config/Constants'
 
 export default function JoinGame() {
   const [playerName, setPlayerName] = useState('')
@@ -21,8 +22,7 @@ export default function JoinGame() {
   const handleSubmit = async (e) => {
     e.preventDefault()
     if (submitting) return
-    const nameRegex = /^[a-zA-Z0-9 _-]{3,20}$/
-    if (!nameRegex.test(playerName)) return
+    if (!USERNAME_REGEX.test(playerName)) return
     setSubmitting(true)
     try {
       await dispatch(

--- a/planningpoker-web/tests/session-labels-csv.spec.js
+++ b/planningpoker-web/tests/session-labels-csv.spec.js
@@ -155,7 +155,7 @@ test.describe('Session Labels', () => {
     }
   })
 
-  test('label broadcasts to non-host on Enter key', async ({ browser }) => {
+  test('Enter key in label input broadcasts label to non-host', async ({ browser }) => {
     const hostCtx = await browser.newContext()
     const playerCtx = await browser.newContext()
     try {
@@ -174,34 +174,6 @@ test.describe('Session Labels', () => {
       // typing-debounce broadcast.
       await labelInput.press('Enter')
       await expect(playerPage.getByText('Deliberate')).toBeVisible({
-        timeout: 15000,
-      })
-    } finally {
-      await hostCtx.close()
-      await playerCtx.close()
-    }
-  })
-
-  test('Enter key in label input broadcasts label', async ({ browser }) => {
-    const hostCtx = await browser.newContext()
-    const playerCtx = await browser.newContext()
-    try {
-      const hostPage = await hostCtx.newPage()
-      const sessionId = await hostGame(hostPage, 'Alice')
-
-      const playerPage = await playerCtx.newPage()
-      await joinGame(playerPage, 'Bob', sessionId)
-
-      await waitForWsReady(playerPage, sessionId, 'Alice')
-
-      const labelInput = hostPage.getByPlaceholder('Item label (optional)')
-
-      // Host types and presses Enter to submit
-      await labelInput.fill('Via Enter')
-      await labelInput.press('Enter')
-
-      // Non-host should see the label via WebSocket
-      await expect(playerPage.getByText('Via Enter')).toBeVisible({
         timeout: 15000,
       })
     } finally {


### PR DESCRIPTION
## Summary
- **Thunk coverage**: added happy-path + failure tests for `kickUser`, `promoteUser`, `setLabel`, and `leaveGame` in `actions/__tests__/index.test.js`. New tests assert the typed action envelope, URL/params, and showError fallback. `setLabel`'s success path exercises the helper's `omitSuccessPayload` (bare `{ type }`) shape from #161. `leaveGame`'s failure case confirms the console-error path doesn't emit further dispatches and still calls `onSuccess`.
- **Vote dispatch ordering**: new `Vote.test.jsx` case pre-spies on `store.dispatch` (so the first render's `useDispatch` captures the spy) and verifies `voteOptimistic` is dispatched before the `vote` thunk on click — the optimistic-first ordering `doVote` relies on for instant card feedback.
- **E2E dedupe**: removed the duplicate "Enter key in label input broadcasts label" test from `session-labels-csv.spec.js` (it tested the same scenario as the test directly above it). Renamed the surviving test for clarity.

## Notes
Branched off `refactor/web-post-form-helper` (#161) since the new thunk tests assume the helper-based shape (e.g. `setLabel` dispatches a payload-less success). Will need to rebase if that PR merges with significant changes, but as-is the diff applies cleanly on top.

## Test plan
- [x] `npm test -- --run` — 232 pass (was 223; +9 new)
- [x] `npm run lint` — clean
- [x] `npx prettier --check` — clean
- [ ] Playwright e2e (CI will run; the dedupe drops one test from the existing 43)