### PR TITLE
fix(release): resolve version from git tag, drop @semantic-release/git

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git
 .claude
 .vscode
 .playwright-mcp

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,11 +5,7 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     ["@semantic-release/exec", {
-      "prepareCmd": "sed -i 's/^version=.*/version=${nextRelease.version}/' planningpoker-api/gradle.properties && cd planningpoker-web && npm run build && cd .. && ./gradlew planningpoker-web:jar --no-daemon && ./gradlew planningpoker-api:bootJar --no-daemon"
-    }],
-    ["@semantic-release/git", {
-      "assets": ["planningpoker-api/gradle.properties"],
-      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      "prepareCmd": "cd planningpoker-web && npm run build && cd .. && ./gradlew planningpoker-web:jar --no-daemon && ./gradlew planningpoker-api:bootJar -PreleaseVersion=${nextRelease.version} --no-daemon"
     }],
     ["@semantic-release/github", {
       "assets": [

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,18 @@ RUN npm run build
 
 # Stage 2: Build backend
 FROM eclipse-temurin:25-jdk AS backend
+RUN apt-get update && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY gradle/ gradle/
 COPY gradlew settings.gradle build.gradle ./
 COPY planningpoker-api/ planningpoker-api/
 COPY planningpoker-web/build.gradle planningpoker-web/build.gradle
 COPY --from=frontend /app/planningpoker-web/build/ planningpoker-web/build/
+# .git lets planningpoker-api/build.gradle resolve the version from the
+# latest git tag at build time. Public repo — .git contents are public.
+# Not carried into the runtime stage below.
+COPY .git/ .git/
 RUN mkdir -p planningpoker-web/dist/libs
 RUN chmod +x gradlew && ./gradlew planningpoker-web:jar --no-daemon
 RUN ./gradlew planningpoker-api:bootJar --no-daemon

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0-semantically-released",
       "devDependencies": {
         "@semantic-release/exec": "^7.1.0",
-        "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^12.0.6",
         "semantic-release": "^25.0.3"
       }
@@ -412,186 +411,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@semantic-release/git": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-10.0.1.tgz",
-      "integrity": "sha512-eWrx5KguUcU2wUPaO6sfvZI0wPafUKAMNC18aXY4EnNcrZL86dEmpNVnC9uMpGZkmZJ9EfCVJBQx4pV4EMGT1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "debug": "^4.0.0",
-        "dir-glob": "^3.0.0",
-        "execa": "^5.0.0",
-        "lodash": "^4.17.4",
-        "micromatch": "^4.0.0",
-        "p-reduce": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=18.0.0"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/@semantic-release/error": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
-      "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/human-signals": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.17.0"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/p-reduce": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
-      "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/@semantic-release/git/node_modules/strip-final-newline": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@semantic-release/github": {
@@ -2300,13 +2119,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.18.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   },
   "devDependencies": {
     "@semantic-release/exec": "^7.1.0",
-    "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^12.0.6",
     "semantic-release": "^25.0.3"
   }

--- a/planningpoker-api/build.gradle
+++ b/planningpoker-api/build.gradle
@@ -6,6 +6,29 @@ plugins {
     id 'com.diffplug.spotless' version '8.4.0'
 }
 
+// Resolve the version stamped into the JAR manifest, in order of precedence:
+//   1. -PreleaseVersion=X.Y.Z — semantic-release's exec step passes the new
+//      version it's about to publish, so the GitHub release JAR asset gets
+//      the right tag baked in.
+//   2. Latest reachable git tag — Railway and local builds resolve the most
+//      recent release without needing a master commit on every release.
+//   3. gradle.properties `version` — final fallback when neither is set
+//      (e.g. .git isn't in the build context).
+def gitTagVersion = { ->
+    try {
+        def proc = ['git', '-C', rootDir.absolutePath, 'describe', '--tags', '--abbrev=0'].execute()
+        proc.waitForOrKill(5000)
+        if (proc.exitValue() == 0) {
+            return proc.text.trim().replaceFirst(/^v/, '')
+        }
+    } catch (Exception ignored) {
+        // git unavailable — fall through
+    }
+    return null
+}
+def releaseOverride = project.findProperty('releaseVersion')
+version = releaseOverride ?: gitTagVersion() ?: project.version
+
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(25)


### PR DESCRIPTION
## Why

PR #157 added `@semantic-release/git` so semantic-release would commit the bumped `gradle.properties` back to master, letting Railway rebuild with the right version. Branch protection blocks that push:

```
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote: - 5 of 5 required status checks are expected.
```

The bot can't push to a branch that requires status checks because its push hasn't been through CI. The release-flow has been broken since #157 merged — `/version` on production has been stuck at `2.3.0` while the latest tag is `v2.7.0`.

The two common fixes both add a long-lived secret (PAT or GitHub App). Owner is allergic to secrets in a public repo, so this PR takes path 2: stop trying to push to master, resolve the version from the latest git tag at build time instead.

## Changes

- **`planningpoker-api/build.gradle`** — resolve version in this order:
  1. `-PreleaseVersion=X.Y.Z` — semantic-release passes this when building the GitHub release JAR, so the asset gets the right tag baked in.
  2. Latest reachable git tag — Railway and local builds, with `.git` in the build context, follow tags without a master commit per release.
  3. `gradle.properties` `version` — final fallback when neither is available.
- **`Dockerfile`** — install `git` in the JDK build stage and `COPY .git/` so `git describe` works during the Railway build. `.git` is not carried into the runtime stage (separate `FROM`).
- **`.dockerignore`** — stop excluding `.git`. Public repo: `.git` contents are already public via GitHub, no leak.
- **`.releaserc.json`** — drop the `@semantic-release/git` plugin block (no master push) and pass `-PreleaseVersion=` to `bootJar` instead of `sed`-ing `gradle.properties`.
- **`package.json` / `package-lock.json`** — drop the now-unused `@semantic-release/git` devDependency.

## Verified locally

- `./gradlew planningpoker-api:jar -PreleaseVersion=9.9.9-test` → manifest `Implementation-Version: 9.9.9-test` ✓
- `./gradlew planningpoker-api:jar` (no override) → manifest `Implementation-Version: 2.7.0` (matches `git describe --tags --abbrev=0`) ✓
- `./gradlew planningpoker-api:test` green
- `./gradlew spotlessCheck` clean

## Trade-off

With no master commit per release, Railway rebuilds only when the next master push lands. `/version` will be at most one release behind the latest tag (vs. the 4-release lag we have today). Closing that gap would mean either:
- Configuring Railway to redeploy on tag push, or
- Switching Railway to pull the GitHub release JAR instead of building from source.

Both are out of scope here. **No secrets, no PAT, no GitHub App.**

## Test plan

- [ ] CI green
- [ ] After merge, watch Railway redeploy from the merge commit
- [ ] `curl https://planning-poker.up.railway.app/version` returns the latest tag (currently `2.7.0`)
- [ ] Next `feat:`/`fix:` PR to master: tag bumps via semantic-release, GH release asset is correctly versioned, Railway redeploys on the next master push and `/version` updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)