### PR TITLE
refactor(deploy): pull JAR from GitHub release instead of rebuilding

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.git
 .claude
 .vscode
 .playwright-mcp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,9 +97,11 @@ Two-module Gradle project: `planningpoker-web` (React 19 frontend) and `planning
 
 ## Deployment
 
-Deployed to Railway via multi-stage Dockerfile (`node:25-alpine` for frontend build, `eclipse-temurin:25-jdk` for backend build, `eclipse-temurin:25-jre` for runtime). Railway config in `railway.toml`. The app reads `$PORT` env var (defaults to 9000). Health check at `/actuator/health`.
+Deployed to Railway via a single-stage Dockerfile (`eclipse-temurin:25-jre`). Railway does **not** rebuild the JAR — instead the Dockerfile fetches the fat JAR semantic-release already produced and attached to the latest GitHub release (filtered by asset *label* `planningpoker.jar`, so the URL is stable across versions). Railway config in `railway.toml`. The app reads `$PORT` env var (defaults to 9000). Health check at `/actuator/health`.
 
-**Automated releases:** semantic-release runs after every green master push. Conventional commit prefixes drive version bumps: `fix:` → patch, `feat:` → minor, `BREAKING CHANGE` footer → major. `chore:`/`docs:`/`test:` commits produce no release. On release, the fat JAR is attached as an asset to the GitHub release and a `v{version}` tag is pushed. Config in `.releaserc.json`.
+**Automated releases:** semantic-release runs after every green master push. Conventional commit prefixes drive version bumps: `fix:` → patch, `feat:` → minor, `BREAKING CHANGE` footer → major. `chore:`/`docs:`/`test:` commits produce no release. On release, the fat JAR is built once in CI (with `-PreleaseVersion=` overriding the version stamped into the manifest), attached as an asset to the GitHub release, and a `v{version}` tag is pushed. Config in `.releaserc.json`.
+
+**Version race:** Railway redeploys on master pushes; semantic-release publishes the new release in parallel. Railway typically clones before the new release finishes uploading, so `/version` is at most one release behind the latest tag. Configuring Railway to redeploy on tag push (or accepting the ~1-release lag) is the trade-off chosen here in exchange for not needing a PAT or GitHub App to bypass branch protection.
 
 Live at: https://planning-poker.up.railway.app
 
@@ -170,7 +172,7 @@ A real-time planning poker web app for distributed teams. Hosts pick an estimati
 - JDK 25 (Eclipse Temurin recommended)
 - Backend on port 9000; frontend dev server on port 3000 (proxies API calls to 9000)
 - Deployed as single fat JAR: `planningpoker-api/build/libs/planningpoker-*.jar`
-- Docker: multi-stage build (`node:25-alpine` for frontend, `eclipse-temurin:25-jdk` for backend build, `eclipse-temurin:25-jre` for runtime)
+- Docker: single-stage runtime (`eclipse-temurin:25-jre`); the fat JAR is fetched from the latest GitHub release rather than rebuilt
 - Health check: `GET /actuator/health`
 
 ## Conventions

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,26 @@
-# Stage 1: Build frontend
-FROM node:25-alpine AS frontend
-WORKDIR /app/planningpoker-web
-COPY planningpoker-web/package.json planningpoker-web/package-lock.json ./
-RUN npm ci
-COPY planningpoker-web/ ./
-RUN npm run build
-
-# Stage 2: Build backend
-FROM eclipse-temurin:25-jdk AS backend
-RUN apt-get update && apt-get install -y --no-install-recommends git \
-    && rm -rf /var/lib/apt/lists/*
-WORKDIR /app
-COPY gradle/ gradle/
-COPY gradlew settings.gradle build.gradle ./
-COPY planningpoker-api/ planningpoker-api/
-COPY planningpoker-web/build.gradle planningpoker-web/build.gradle
-COPY --from=frontend /app/planningpoker-web/build/ planningpoker-web/build/
-# .git lets planningpoker-api/build.gradle resolve the version from the
-# latest git tag at build time. Public repo — .git contents are public.
-# Not carried into the runtime stage below.
-COPY .git/ .git/
-RUN mkdir -p planningpoker-web/dist/libs
-RUN chmod +x gradlew && ./gradlew planningpoker-web:jar --no-daemon
-RUN ./gradlew planningpoker-api:bootJar --no-daemon
-
-# Stage 3: Runtime
+# Single-stage: pull the JAR that semantic-release already built and uploaded
+# to the latest GitHub release, instead of recompiling from source.
+#
+# Filter by asset *label* ("planningpoker.jar") rather than asset name —
+# semantic-release uploads with the version-suffixed filename
+# (planningpoker-api-X.Y.Z.jar) but applies the stable label, so this works
+# for every release v2.7.0+ without needing a transition.
+#
+# RAILWAY_GIT_COMMIT_SHA is auto-injected by Railway and busts the Docker
+# layer cache on every master commit, ensuring we re-fetch when a new
+# release lands.
 FROM eclipse-temurin:25-jre
-RUN addgroup --system app && adduser --system --ingroup app app
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates jq \
+    && rm -rf /var/lib/apt/lists/* \
+    && addgroup --system app && adduser --system --ingroup app app
 WORKDIR /app
-COPY --from=backend /app/planningpoker-api/build/libs/planningpoker-*.jar app.jar
+ARG RAILWAY_GIT_COMMIT_SHA=local
+RUN echo "fetching latest planningpoker.jar for ${RAILWAY_GIT_COMMIT_SHA}" \
+    && URL=$(curl -fsSL "https://api.github.com/repos/richashworth/planningpoker/releases/latest" \
+              | jq -er '.assets[] | select(.label == "planningpoker.jar") | .browser_download_url') \
+    && echo "downloading $URL" \
+    && curl -fsSL "$URL" -o app.jar \
+    && chown app:app app.jar
 USER app
 ENTRYPOINT ["java", "-Djava.security.egd=file:/dev/./urandom", "-jar", "app.jar"]


### PR DESCRIPTION
## Why

Today Railway rebuilds the fat JAR from source on every master push: 3-stage Docker (node:25-alpine for frontend + eclipse-temurin:25-jdk for backend compile + eclipse-temurin:25-jre for runtime), apt-get install git, \`COPY .git/\`, and a \`git describe\` block in \`build.gradle\` to bake the version into the JAR manifest. Meanwhile CI builds the *same* JAR — once for the GitHub release asset.

That's redundant. semantic-release already produces a versioned fat JAR and uploads it to the GH release. Railway should just fetch that JAR.

## Changes

- **Dockerfile** — collapses to a single \`eclipse-temurin:25-jre\` stage. Queries the GitHub releases API for the latest release, filters assets by label \`planningpoker.jar\` (which semantic-release applies across versions), curls the asset URL. \`RAILWAY_GIT_COMMIT_SHA\` is consumed as a build arg to bust the layer cache on every master commit.
- **.dockerignore** — re-excludes \`.git\` (no longer needed in build context).
- **CLAUDE.md** — Deployment and Platform-Requirements sections updated.

The \`git describe\` block in \`build.gradle\` is left in place — still useful for local \`./gradlew bootRun\` and harmless in CI (the \`-PreleaseVersion=\` Gradle property override takes precedence for the actual release build).

## Verified locally

The novel logic — discover-and-download via GH API + jq — was tested standalone:

\`\`\`
$ curl -fsSL https://api.github.com/repos/richashworth/planningpoker/releases/latest \\
    | jq -er '.assets[] | select(.label == \"planningpoker.jar\") | .browser_download_url'
https://github.com/richashworth/planningpoker/releases/download/v2.7.1/planningpoker-api-2.7.1.jar
$ curl -sIL <url> | head
HTTP/2 302
HTTP/2 200
content-type: application/octet-stream
content-length: 26411295
\`\`\`

Docker build itself will be exercised by CI's \`docker-build\` job.

## Trade-off

Same one-release version lag as PR #165's approach: Railway typically clones before semantic-release publishes the new release, so \`/version\` shows the previous tag until the next master push. No worse than today's behaviour.

## What disappears

- Frontend Docker stage (\`npm ci\` + \`npm run build\`) — JAR already contains the bundled web assets.
- Backend Docker stage (\`./gradlew bootJar\`) — no second JAR build per release.
- \`apt-get install git\`, \`COPY .git/\` in Dockerfile.

Net diff: -32 / +28 across 3 files. Build time on Railway should drop from ~2-3 min to ~30 s.

## Test plan

- [ ] CI green (especially \`docker-build\`)
- [ ] After merge, watch Railway redeploy
- [ ] \`curl https://planning-poker.up.railway.app/version\` returns \`2.7.1\` (the latest tag at deploy time)
- [ ] App functional end-to-end (host, join, vote, refresh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)