### PR TITLE
fix(web): inline username validation errors and lower min length to 2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ Two-module Gradle project: `planningpoker-web` (React 19 frontend) and `planning
 
 ## Validation Rules
 
-- Usernames: 3-20 chars, alphanumeric + spaces/hyphens/underscores only
+- Usernames: 2-20 chars, alphanumeric + spaces/hyphens/underscores only
 - Vote values: server-side whitelist derived from the session's `SchemeConfig` via `SessionManager.getSessionLegalValues`
 - Session membership required for voting, resetting, and logging out
 - No authentication — users are identified by name within a session

--- a/planningpoker-api/src/main/java/com/richashworth/planningpoker/controller/GameController.java
+++ b/planningpoker-api/src/main/java/com/richashworth/planningpoker/controller/GameController.java
@@ -30,7 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class GameController {
 
   private static final int MAX_USERNAME_LENGTH = 20;
-  private static final int MIN_USERNAME_LENGTH = 3;
+  private static final int MIN_USERNAME_LENGTH = 2;
   private static final String USERNAME_PATTERN = "^[a-zA-Z0-9 _-]+$";
 
   private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/GameControllerTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/GameControllerTest.java
@@ -276,7 +276,7 @@ class GameControllerTest extends AbstractControllerTest {
 
   @Test
   void testCreateSessionRejectsShortName() {
-    CreateSessionRequest request = new CreateSessionRequest("AB", null, null, null);
+    CreateSessionRequest request = new CreateSessionRequest("A", null, null, null);
     assertThrows(IllegalArgumentException.class, () -> gameController.createSession(request));
   }
 

--- a/planningpoker-web/src/components/NameInput.jsx
+++ b/planningpoker-web/src/components/NameInput.jsx
@@ -1,7 +1,13 @@
 import TextField from '@mui/material/TextField'
-import { USERNAME_PATTERN } from '../config/Constants'
+import {
+  USERNAME_HELPER,
+  USERNAME_MAX,
+  USERNAME_PATTERN,
+  USERNAME_REGEX,
+} from '../config/Constants'
 
 export default function NameInput({ playerName, onPlayerNameInputChange }) {
+  const showError = playerName.length > 0 && !USERNAME_REGEX.test(playerName)
   return (
     <TextField
       label="Your Name"
@@ -10,10 +16,12 @@ export default function NameInput({ playerName, onPlayerNameInputChange }) {
       autoFocus
       required
       fullWidth
+      error={showError}
+      helperText={USERNAME_HELPER}
       slotProps={{
         htmlInput: {
           pattern: USERNAME_PATTERN,
-          title: 'Name must be 3-20 characters: letters, numbers, spaces, hyphens, or underscores',
+          maxLength: USERNAME_MAX,
         },
       }}
       sx={{ mb: 2.5 }}

--- a/planningpoker-web/src/config/Constants.js
+++ b/planningpoker-web/src/config/Constants.js
@@ -1,10 +1,13 @@
 export const API_ROOT_URL = ''
 
 // Username constraint shared by NameInput's HTML pattern attribute and the
-// JS-side guard in CreateGame/JoinGame. 3-20 chars: letters, digits, spaces,
+// JS-side guard in CreateGame/JoinGame. 2-20 chars: letters, digits, spaces,
 // hyphens, underscores. The anchored RegExp is derived from the same source.
-export const USERNAME_PATTERN = '[a-zA-Z0-9 _-]{3,20}'
+export const USERNAME_MIN = 2
+export const USERNAME_MAX = 20
+export const USERNAME_PATTERN = `[a-zA-Z0-9 _-]{${USERNAME_MIN},${USERNAME_MAX}}`
 export const USERNAME_REGEX = new RegExp(`^${USERNAME_PATTERN}$`)
+export const USERNAME_HELPER = `${USERNAME_MIN}-${USERNAME_MAX} characters: letters, numbers, spaces, hyphens, underscores`
 
 export const SCHEME_VALUES = {
   fibonacci: ['1', '2', '3', '5', '8', '13'],

--- a/planningpoker-web/src/pages/CreateGame.jsx
+++ b/planningpoker-web/src/pages/CreateGame.jsx
@@ -57,10 +57,12 @@ export default function CreateGame() {
     return msg === '' || msg === 'Duplicate values removed'
   }
 
+  const isNameValid = USERNAME_REGEX.test(playerName)
+
   const handleSubmit = async (e) => {
     e.preventDefault()
     if (submitting) return
-    if (!USERNAME_REGEX.test(playerName)) return
+    if (!isNameValid) return
     if (!isCustomValid()) return
     setSubmitting(true)
     try {
@@ -175,7 +177,7 @@ export default function CreateGame() {
               fullWidth
               size="large"
               disableElevation
-              disabled={!isCustomValid() || submitting}
+              disabled={!isNameValid || !isCustomValid() || submitting}
             >
               {submitting ? <CircularProgress size={20} sx={{ mr: 1 }} /> : null}
               Start Game

--- a/planningpoker-web/src/pages/JoinGame.jsx
+++ b/planningpoker-web/src/pages/JoinGame.jsx
@@ -19,10 +19,12 @@ export default function JoinGame() {
   const dispatch = useDispatch()
   const navigate = useNavigate()
 
+  const isNameValid = USERNAME_REGEX.test(playerName)
+
   const handleSubmit = async (e) => {
     e.preventDefault()
     if (submitting) return
-    if (!USERNAME_REGEX.test(playerName)) return
+    if (!isNameValid) return
     setSubmitting(true)
     try {
       await dispatch(
@@ -64,7 +66,7 @@ export default function JoinGame() {
               fullWidth
               size="large"
               disableElevation
-              disabled={submitting}
+              disabled={!isNameValid || submitting}
             >
               {submitting ? <CircularProgress size={20} sx={{ mr: 1 }} /> : null}
               Join Game

--- a/specs/summary.md
+++ b/specs/summary.md
@@ -28,7 +28,7 @@
 ### Transitions
 - **Session: (new) -> active**
   - Trigger: createSession API call
-  - Guard: valid username (3-20 chars, alphanumeric + spaces/hyphens/underscores)
+  - Guard: valid username (2-20 chars, alphanumeric + spaces/hyphens/underscores)
 
 - **Session: active -> cleared**
   - Trigger: ClearSessionsTask fires


### PR DESCRIPTION
## Summary
- Replace the browser's native constraint-validation tooltip on the username field with MUI inline `error` + `helperText`. The rule (\"2-20 characters: letters, numbers, spaces, hyphens, underscores\") is now always visible as helper text, and the field turns red as soon as the typed value violates the pattern.
- Disable the **Join Game** / **Start Game** button while the name is invalid so the CTA state matches the field state, instead of silently no-op'ing on submit.
- Lower the minimum username length from 3 to 2 chars (frontend + backend); maximum stays at 20 to keep usernames within the layout budget of the users-list sidebar, results-table rows, and chart x-axis labels.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 232/232
- [x] `./gradlew planningpoker-api:test` — full suite green
- [x] `cd planningpoker-web && npx playwright test` — 42/42
- [x] Manual: type a 1-char name → field red, helper text shown, submit disabled
- [ ] Manual: type a valid name → no red, submit enabled
- [ ] Manual: paste 25 chars → input caps at 20

🤖 Generated with [Claude Code](https://claude.com/claude-code)