### PR TITLE
fix(web): username validation UX + card sizing for long labels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ Two-module Gradle project: `planningpoker-web` (React 19 frontend) and `planning
 
 ## Validation Rules
 
-- Usernames: 3-20 chars, alphanumeric + spaces/hyphens/underscores only
+- Usernames: 2-20 chars, alphanumeric + spaces/hyphens/underscores only
 - Vote values: server-side whitelist derived from the session's `SchemeConfig` via `SessionManager.getSessionLegalValues`
 - Session membership required for voting, resetting, and logging out
 - No authentication — users are identified by name within a session

--- a/planningpoker-api/src/main/java/com/richashworth/planningpoker/controller/GameController.java
+++ b/planningpoker-api/src/main/java/com/richashworth/planningpoker/controller/GameController.java
@@ -30,7 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class GameController {
 
   private static final int MAX_USERNAME_LENGTH = 20;
-  private static final int MIN_USERNAME_LENGTH = 3;
+  private static final int MIN_USERNAME_LENGTH = 2;
   private static final String USERNAME_PATTERN = "^[a-zA-Z0-9 _-]+$";
 
   private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/GameControllerTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/controller/GameControllerTest.java
@@ -276,7 +276,7 @@ class GameControllerTest extends AbstractControllerTest {
 
   @Test
   void testCreateSessionRejectsShortName() {
-    CreateSessionRequest request = new CreateSessionRequest("AB", null, null, null);
+    CreateSessionRequest request = new CreateSessionRequest("A", null, null, null);
     assertThrows(IllegalArgumentException.class, () -> gameController.createSession(request));
   }
 

--- a/planningpoker-web/src/components/ConsensusCardRail.jsx
+++ b/planningpoker-web/src/components/ConsensusCardRail.jsx
@@ -30,9 +30,11 @@ export default function ConsensusCardRail({ legalEstimates, results, value, onCh
               onClick={() => onChange(v)}
               sx={{
                 position: 'relative',
-                width: 44,
-                height: 58,
-                p: 0,
+                minWidth: 44,
+                minHeight: 58,
+                px: 1,
+                py: 0,
+                whiteSpace: 'nowrap',
                 borderRadius: '6px',
                 border: '1.5px solid',
                 borderColor: selected ? 'primary.main' : 'divider',

--- a/planningpoker-web/src/components/NameInput.jsx
+++ b/planningpoker-web/src/components/NameInput.jsx
@@ -1,7 +1,13 @@
 import TextField from '@mui/material/TextField'
-import { USERNAME_PATTERN } from '../config/Constants'
+import {
+  USERNAME_HELPER,
+  USERNAME_MAX,
+  USERNAME_PATTERN,
+  USERNAME_REGEX,
+} from '../config/Constants'
 
 export default function NameInput({ playerName, onPlayerNameInputChange }) {
+  const showError = playerName.length > 0 && !USERNAME_REGEX.test(playerName)
   return (
     <TextField
       label="Your Name"
@@ -10,10 +16,12 @@ export default function NameInput({ playerName, onPlayerNameInputChange }) {
       autoFocus
       required
       fullWidth
+      error={showError}
+      helperText={USERNAME_HELPER}
       slotProps={{
         htmlInput: {
           pattern: USERNAME_PATTERN,
-          title: 'Name must be 3-20 characters: letters, numbers, spaces, hyphens, or underscores',
+          maxLength: USERNAME_MAX,
         },
       }}
       sx={{ mb: 2.5 }}

--- a/planningpoker-web/src/config/Constants.js
+++ b/planningpoker-web/src/config/Constants.js
@@ -1,10 +1,13 @@
 export const API_ROOT_URL = ''
 
 // Username constraint shared by NameInput's HTML pattern attribute and the
-// JS-side guard in CreateGame/JoinGame. 3-20 chars: letters, digits, spaces,
+// JS-side guard in CreateGame/JoinGame. 2-20 chars: letters, digits, spaces,
 // hyphens, underscores. The anchored RegExp is derived from the same source.
-export const USERNAME_PATTERN = '[a-zA-Z0-9 _-]{3,20}'
+export const USERNAME_MIN = 2
+export const USERNAME_MAX = 20
+export const USERNAME_PATTERN = `[a-zA-Z0-9 _-]{${USERNAME_MIN},${USERNAME_MAX}}`
 export const USERNAME_REGEX = new RegExp(`^${USERNAME_PATTERN}$`)
+export const USERNAME_HELPER = `${USERNAME_MIN}-${USERNAME_MAX} characters: letters, numbers, spaces, hyphens, underscores`
 
 export const SCHEME_VALUES = {
   fibonacci: ['1', '2', '3', '5', '8', '13'],

--- a/planningpoker-web/src/containers/Vote.jsx
+++ b/planningpoker-web/src/containers/Vote.jsx
@@ -8,7 +8,10 @@ import SessionHistory from './SessionHistory'
 
 function cardSx(isSelected, isDisabled) {
   return {
-    aspectRatio: '3 / 4',
+    minWidth: 80,
+    minHeight: 107,
+    px: 1.5,
+    whiteSpace: 'nowrap',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
@@ -85,8 +88,8 @@ export default function Vote({ consensusOverride = null }) {
         <Box sx={{ gridArea: 'cards', minWidth: 0 }}>
           <Box
             sx={{
-              display: 'grid',
-              gridTemplateColumns: 'repeat(auto-fill, minmax(80px, 1fr))',
+              display: 'flex',
+              flexWrap: 'wrap',
               gap: 0.75,
             }}
           >

--- a/planningpoker-web/src/pages/CreateGame.jsx
+++ b/planningpoker-web/src/pages/CreateGame.jsx
@@ -57,10 +57,12 @@ export default function CreateGame() {
     return msg === '' || msg === 'Duplicate values removed'
   }
 
+  const isNameValid = USERNAME_REGEX.test(playerName)
+
   const handleSubmit = async (e) => {
     e.preventDefault()
     if (submitting) return
-    if (!USERNAME_REGEX.test(playerName)) return
+    if (!isNameValid) return
     if (!isCustomValid()) return
     setSubmitting(true)
     try {
@@ -175,7 +177,7 @@ export default function CreateGame() {
               fullWidth
               size="large"
               disableElevation
-              disabled={!isCustomValid() || submitting}
+              disabled={!isNameValid || !isCustomValid() || submitting}
             >
               {submitting ? <CircularProgress size={20} sx={{ mr: 1 }} /> : null}
               Start Game

--- a/planningpoker-web/src/pages/JoinGame.jsx
+++ b/planningpoker-web/src/pages/JoinGame.jsx
@@ -19,10 +19,12 @@ export default function JoinGame() {
   const dispatch = useDispatch()
   const navigate = useNavigate()
 
+  const isNameValid = USERNAME_REGEX.test(playerName)
+
   const handleSubmit = async (e) => {
     e.preventDefault()
     if (submitting) return
-    if (!USERNAME_REGEX.test(playerName)) return
+    if (!isNameValid) return
     setSubmitting(true)
     try {
       await dispatch(
@@ -64,7 +66,7 @@ export default function JoinGame() {
               fullWidth
               size="large"
               disableElevation
-              disabled={submitting}
+              disabled={!isNameValid || submitting}
             >
               {submitting ? <CircularProgress size={20} sx={{ mr: 1 }} /> : null}
               Join Game

--- a/specs/summary.md
+++ b/specs/summary.md
@@ -28,7 +28,7 @@
 ### Transitions
 - **Session: (new) -> active**
   - Trigger: createSession API call
-  - Guard: valid username (3-20 chars, alphanumeric + spaces/hyphens/underscores)
+  - Guard: valid username (2-20 chars, alphanumeric + spaces/hyphens/underscores)
 
 - **Session: active -> cleared**
   - Trigger: ClearSessionsTask fires


### PR DESCRIPTION
## Summary
- Inline username validation errors (red border + helper text) and lower min length from 3 to 2 chars
- Vote and consensus cards now grow horizontally to fit long custom-scheme labels (e.g. \"Bigger\", \"Enormous\") and never shrink below their baseline size

## Test plan
- [x] Verified locally with custom scheme \`Big, Bigger, Massive, Enormous\` — all four labels fit without clipping in both the voting grid and the consensus rail
- [ ] CI green (lint, build-web, unit-tests, e2e-tests, docker-build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)