### PR TITLE
fix(api): widen session IDs to 12 URL-safe Base64 chars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Two-module Gradle project: `planningpoker-web` (React 19 frontend) and `planning
 ### Backend
 
 - **Spring Boot 4.0** with Java 25
-- **State management:** All session state is in-memory (synchronized Guava `ListMultimap`). Session IDs are random 8-char UUID prefixes. A scheduled task (`ClearSessionsTask`) periodically clears all sessions.
+- **State management:** All session state is in-memory (synchronized Guava `ListMultimap`). Session IDs are 12-char URL-safe Base64 tokens (9 random bytes from `SecureRandom`). A scheduled task (`ClearSessionsTask`) periodically clears all sessions.
 - **SPA routing:** `SpaWebConfig` forwards unknown routes to `index.html` so client-side routing works on page refresh.
 - **State sync:** After a mutation, `MessagingUtils.sendResultsMessage()` / `sendUsersMessage()` publishes a single typed `Message` envelope to the relevant `/topic/...`. Clients reconcile via a monotonic `round` (epoch) counter: a newer round replaces state, an equal round unions results, older rounds are ignored — so duplicate or out-of-order broadcasts are idempotent.
 
@@ -115,7 +115,7 @@ A real-time planning poker web app for distributed teams. Hosts pick an estimati
 
 - **Tech stack**: Spring Boot 4.0 + Java 25 backend, React 19 + MUI v9 + Redux 5 + RTK frontend — no new frameworks
 - **In-memory state**: No database — all session state lives in `SessionManager` and is ephemeral
-- **No authentication**: users are identified by name within a session; the 8-char session ID is the only access control
+- **No authentication**: users are identified by name within a session; the 12-char session ID is the only access control
 
 ## Technology Stack
 

--- a/planningpoker-api/src/main/java/com/richashworth/planningpoker/service/SessionManager.java
+++ b/planningpoker-api/src/main/java/com/richashworth/planningpoker/service/SessionManager.java
@@ -8,6 +8,7 @@ import com.richashworth.planningpoker.model.Round;
 import com.richashworth.planningpoker.model.SchemeConfig;
 import com.richashworth.planningpoker.model.SchemeType;
 import com.richashworth.planningpoker.util.LogSafeIds;
+import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -22,6 +23,10 @@ public class SessionManager {
 
   static final int MAX_SESSIONS = 100_000;
   static final int MAX_ID_ATTEMPTS = 100;
+
+  private static final int SESSION_ID_RANDOM_BYTES = 9;
+  private static final SecureRandom SESSION_ID_RNG = new SecureRandom();
+  private static final Base64.Encoder SESSION_ID_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -62,7 +67,7 @@ public class SessionManager {
         throw new IllegalStateException(
             "Failed to generate unique session ID after " + MAX_ID_ATTEMPTS + " attempts");
       }
-      sessionId = UUID.randomUUID().toString().substring(0, 8);
+      sessionId = generateSessionId();
       attempts++;
     } while (activeSessions.contains(sessionId));
     activeSessions.add(sessionId);
@@ -292,5 +297,11 @@ public class SessionManager {
     if (!toEvict.isEmpty()) {
       logger.info("Evicted {} idle session(s)", toEvict.size());
     }
+  }
+
+  private static String generateSessionId() {
+    byte[] bytes = new byte[SESSION_ID_RANDOM_BYTES];
+    SESSION_ID_RNG.nextBytes(bytes);
+    return SESSION_ID_ENCODER.encodeToString(bytes);
   }
 }

--- a/planningpoker-api/src/main/java/com/richashworth/planningpoker/util/LogSafeIds.java
+++ b/planningpoker-api/src/main/java/com/richashworth/planningpoker/util/LogSafeIds.java
@@ -8,9 +8,8 @@ import java.security.NoSuchAlgorithmException;
  * Produces short, deterministic, non-reversible identifiers for log correlation. Used instead of
  * raw session IDs or usernames so logs carry no PII.
  *
- * <p>NOTE on reversibility: SHA-256 on an 8-char session ID is theoretically brute-forceable
- * offline, but session IDs are ephemeral (evicted after 24h idle) and contain no user data. This
- * residual risk is explicitly accepted (see phase 13 threat model T-13-04).
+ * <p>SHA-256 truncated to 8 hex chars: collision-tolerant (used for grep, not uniqueness) and
+ * non-reversible against 12-char URL-safe Base64 session IDs (~2⁷² input space).
  */
 public final class LogSafeIds {
 

--- a/planningpoker-api/src/test/java/com/richashworth/planningpoker/service/SessionManagerTest.java
+++ b/planningpoker-api/src/test/java/com/richashworth/planningpoker/service/SessionManagerTest.java
@@ -292,7 +292,9 @@ class SessionManagerTest {
     SchemeConfig config = new SchemeConfig("fibonacci", null, true);
     String sessionId = sessionManager.createSession(config);
     assertNotNull(sessionId);
-    assertEquals(8, sessionId.length());
+    assertEquals(12, sessionId.length());
+    assertTrue(
+        sessionId.matches("[A-Za-z0-9_-]{12}"), "session ID should be 12 URL-safe Base64 chars");
     assertTrue(sessionManager.isSessionActive(sessionId));
     List<String> legalValues = sessionManager.getSessionLegalValues(sessionId);
     assertTrue(legalValues.contains("1"));

--- a/planningpoker-web/src/pages/JoinGame.jsx
+++ b/planningpoker-web/src/pages/JoinGame.jsx
@@ -60,8 +60,8 @@ export default function JoinGame() {
               required
               fullWidth
               sx={{ mb: 1 }}
-              helperText="8-character session ID"
-              slotProps={{ htmlInput: { maxLength: 8 } }}
+              helperText="12-character session ID"
+              slotProps={{ htmlInput: { maxLength: 12 } }}
             />
             <FormControlLabel
               control={

--- a/planningpoker-web/tests/planning-poker.spec.js
+++ b/planningpoker-web/tests/planning-poker.spec.js
@@ -41,7 +41,7 @@ test.describe('Host a Game', () => {
     await page.getByRole('button', { name: 'Start Game' }).click()
     await expect(page).toHaveURL('/game')
 
-    await expect(page.locator('.MuiChip-label')).toHaveText(/^Session ID: [a-f0-9]{8}$/)
+    await expect(page.locator('.MuiChip-label')).toHaveText(/^Session ID: [A-Za-z0-9_-]{12}$/)
   })
 
   test('host can vote and see results', async ({ page }) => {

--- a/planningpoker-web/tests/session-labels-csv.spec.js
+++ b/planningpoker-web/tests/session-labels-csv.spec.js
@@ -347,7 +347,7 @@ test.describe('CSV Export', () => {
       await exportBtn.scrollIntoViewIfNeeded()
       const [download] = await Promise.all([hostPage.waitForEvent('download'), exportBtn.click()])
 
-      expect(download.suggestedFilename()).toMatch(/^planning-poker-[a-f0-9]+\.csv$/)
+      expect(download.suggestedFilename()).toMatch(/^planning-poker-[A-Za-z0-9_-]+\.csv$/)
 
       // Verify CSV content
       const content = await download.path().then((p) => {
@@ -422,7 +422,7 @@ test.describe('CSV Export', () => {
         playerPage.waitForEvent('download'),
         playerExport.click(),
       ])
-      expect(download.suggestedFilename()).toMatch(/^planning-poker-[a-f0-9]+\.csv$/)
+      expect(download.suggestedFilename()).toMatch(/^planning-poker-[A-Za-z0-9_-]+\.csv$/)
       const content = await download.path().then((p) => {
         // eslint-disable-next-line no-undef
         const fs = require('fs')

--- a/specs/summary.md
+++ b/specs/summary.md
@@ -1,7 +1,7 @@
 ## System: PlanningPoker
 
 ### Entities
-- **Session**: A planning poker estimation session identified by 8-char UUID prefix
+- **Session**: A planning poker estimation session identified by 12-char URL-safe Base64 token
   - Type: resource
   - Count: unbounded
   - States: active, cleared


### PR DESCRIPTION
## Summary
- Replace 8-char UUID prefix (32 bits, hex) with 12-char URL-safe Base64 from `SecureRandom` (72 bits) — clears NIST SP 800-63B / OWASP ASVS thresholds
- Refresh `LogSafeIds` doc comment, frontend helper text + `maxLength`, and CLAUDE.md / specs/summary.md to match
- Tighten `SessionManagerTest.testCreateSessionWithScheme` to assert both length and URL-safe-Base64 alphabet so a regression in the generator is caught

Closes #138

## Test plan
- [x] Backend unit tests (173/173 passing locally)
- [x] Frontend unit tests (233/233 passing locally)
- [x] Playwright e2e (43/43 passing locally; updated 3 hardcoded `[a-f0-9]` regex assumptions in tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)