### PR TITLE
fix(web): drop noisy "n of n" suffix from votes table header

### DIFF
--- a/planningpoker-web/src/containers/ResultsTable.jsx
+++ b/planningpoker-web/src/containers/ResultsTable.jsx
@@ -59,7 +59,7 @@ export default function ResultsTable() {
           '& .MuiButton-startIcon': { mr: 0.5 },
         }}
       >
-        Votes · {results.length} of {voters.length}
+        Votes
       </Button>
       {open && (
         <Box


### PR DESCRIPTION
## Summary
- The votes table header was showing `Votes · 2 of 5` — the running count is just noise. Header now reads `Votes`.

## Test plan
- [ ] Open a session, cast votes, confirm header reads `Votes` and the table content still works