### PR TITLE
fix(deploy): version stamping + explicit Railway builder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git
 .claude
 .vscode
 .playwright-mcp

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,10 @@ COPY gradlew gradlew.bat settings.gradle build.gradle ./
 COPY gradle ./gradle
 COPY planningpoker-web/build.gradle ./planningpoker-web/build.gradle
 COPY planningpoker-api ./planningpoker-api
+# .git is needed so build.gradle's gitTagVersion() can resolve `git describe`
+# and stamp the real release tag into the JAR manifest. Without it /version
+# falls back to the gradle.properties default and lies about the running build.
+COPY .git ./.git
 # Bring in the freshly built frontend so planningpoker-web:jar can package it
 COPY --from=web-builder /web/build ./planningpoker-web/build
 RUN ./gradlew planningpoker-web:jar --no-daemon

--- a/railway.toml
+++ b/railway.toml
@@ -1,3 +1,7 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
+
 [deploy]
 startCommand = "/app/planningpoker"
 healthcheckPath = "/actuator/health"


### PR DESCRIPTION
## Two related deploy fixes after observing the post-merge behavior of #178

### 1. /version returns gradle.properties default (\`2.3.0\`) on production

The Dockerfile build context excludes \`.git\` (.dockerignore had it listed), so \`gitTagVersion()\` in \`build.gradle\` can't run \`git describe --tags --abbrev=0\` inside the build container. It falls back to \`project.version\` from \`gradle.properties\`, which is \`2.3.0\`.

**Fix:** drop \`.git\` from \`.dockerignore\` and \`COPY .git ./.git\` in the native-builder stage. Adds ~80 MB to the build context but only in the build stage; runtime image is unchanged.

**Caveat:** if Railway's source snapshot strips \`.git\` before the build (haven't verified yet), this won't be sufficient and we'll need to switch to \`\$RAILWAY_GIT_COMMIT_SHA\` as a build-arg fallback. I'll verify post-deploy.

### 2. Explicit \`[build]\` section in \`railway.toml\`

When PR #178 stripped \`[build]\` from \`railway.toml\` (assuming Dockerfile was the implicit default), the first post-merge Railway deploy initially showed \`builder = \"RAILPACK\"\` in the metadata. Turned out to be a transient state — Railway eventually picked up the file and did the right thing — but explicit > implicit for deploy config.

**Fix:** re-add \`[build]\` with \`builder = \"DOCKERFILE\"\` + \`dockerfilePath = \"Dockerfile\"\`. Defense in depth.

## Test plan

- [ ] CI green
- [ ] After merge, Railway deploy from master sets \`builder = DOCKERFILE\` from the start
- [ ] \`curl https://planning-poker.up.railway.app/version\` returns the latest tag (e.g. \`2.8.3\`+) instead of \`2.3.0\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)