### PR TITLE
fix(deploy): revert .git copy from Dockerfile (Railway strips it)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.git
 .claude
 .vscode
 .playwright-mcp

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,6 @@ COPY gradlew gradlew.bat settings.gradle build.gradle ./
 COPY gradle ./gradle
 COPY planningpoker-web/build.gradle ./planningpoker-web/build.gradle
 COPY planningpoker-api ./planningpoker-api
-# .git is needed so build.gradle's gitTagVersion() can resolve `git describe`
-# and stamp the real release tag into the JAR manifest. Without it /version
-# falls back to the gradle.properties default and lies about the running build.
-COPY .git ./.git
 # Bring in the freshly built frontend so planningpoker-web:jar can package it
 COPY --from=web-builder /web/build ./planningpoker-web/build
 RUN ./gradlew planningpoker-web:jar --no-daemon


### PR DESCRIPTION
## Why

PR #179 included a \`COPY .git ./.git\` step in the Dockerfile to fix \`/version\` returning \`2.3.0\` (the gradle.properties default) instead of the real release tag. **Doesn't work** — Railway strips \`.git\` from the build snapshot in both \`railway up\` and GitHub-source modes, so the COPY fails with:

\`\`\`
failed to compute cache key: failed to calculate checksum of ref ... \"/.git\": not found
\`\`\`

This breaks every deploy attempt. Production is currently still serving the older \`b54f228\` deploy (which had \`/version = 2.3.0\` but at least built successfully).

## Fix

Revert the \`.dockerignore\` and \`Dockerfile\` changes from #179. Keep the explicit \`[build]\` section in \`railway.toml\` — that's harmless defense in depth.

## Open: how do we actually fix /version?

Two approaches available; not in scope for this PR:

1. **Dockerfile build-arg from Railway env**: \`railway.toml\` can pass build-args, and Railway injects \`RAILWAY_GIT_COMMIT_SHA\` at deploy time. Could expose commit SHA as the version. Quick.

2. **semantic-release writes version to a tracked file**: re-add \`@semantic-release/exec\` + \`@semantic-release/git\` so each release commits a \`VERSION\` file that the Dockerfile reads. Closer to the original behavior. More moving parts.

Whichever path we take is a follow-up.

## Test plan

- [ ] CI green (no source code change, all checks should pass)
- [ ] After merge, Railway deploy from master succeeds and serves traffic
- [ ] /actuator/health returns 200
- [ ] Smoke endpoints still work (createSession, refresh, stomp/info)
- [x] /version stays at 2.3.0 — known issue, fix tracked separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)