### PR TITLE
refactor(web): drop version display from footer

### DIFF
--- a/planningpoker-web/src/components/Footer.jsx
+++ b/planningpoker-web/src/components/Footer.jsx
@@ -1,19 +1,7 @@
-import { useState, useEffect } from 'react'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
-import axios from 'axios'
-import { API_ROOT_URL } from '../config/Constants'
 
 export default function Footer() {
-  const [appVersion, setAppVersion] = useState('')
-
-  useEffect(() => {
-    axios
-      .get(`${API_ROOT_URL}/version`)
-      .then((res) => setAppVersion(res.data))
-      .catch(() => {})
-  }, [])
-
   return (
     <Box
       component="footer"
@@ -30,9 +18,6 @@ export default function Footer() {
     >
       <Typography variant="caption" sx={{ color: 'text.disabled', fontSize: '0.7rem' }}>
         &copy; {new Date().getFullYear()} Rich Ashworth
-      </Typography>
-      <Typography variant="caption" sx={{ color: 'text.disabled', fontSize: '0.7rem' }}>
-        {appVersion ? `v${appVersion}` : ''}
       </Typography>
     </Box>
   )


### PR DESCRIPTION
## Why

End users don't track release versions and don't reference them in bug reports. Showing \`v\${appVersion}\` in the footer added no UX value but kept us on the hook for accurate version stamping inside the build container — which is non-trivial because Railway strips \`.git\` from snapshots, so \`gitTagVersion()\` falls back to the gradle.properties default (\`2.3.0\`) and the footer lies.

Removing the UI display makes the version stamping bug a non-issue.

## Scope

- Delete the \`useState\`/\`useEffect\` block in \`Footer.jsx\` that fetched \`/version\`
- Delete the right-aligned \`Typography\` that rendered it
- Strip the now-unused imports (\`useState\`, \`useEffect\`, \`axios\`, \`API_ROOT_URL\`)

The \`/version\` REST endpoint stays — still useful for monitoring scripts and curl checks. Backend code (\`AppController\`, \`gitTagVersion()\` in \`build.gradle\`, \`gradle.properties\`) untouched.

## Test plan

- [ ] CI green (no test references the footer version)
- [ ] Manually verify the footer still shows the copyright on the left after merge
- [ ] /version endpoint still responds for ops tooling

🤖 Generated with [Claude Code](https://claude.com/claude-code)