### PR TITLE
fix(web): hide "Session ID" prefix on mobile to prevent header overflow

### DIFF
--- a/planningpoker-web/src/containers/Header.jsx
+++ b/planningpoker-web/src/containers/Header.jsx
@@ -12,6 +12,8 @@ import MenuItem from '@mui/material/MenuItem'
 import ListItemIcon from '@mui/material/ListItemIcon'
 import ListItemText from '@mui/material/ListItemText'
 import Tooltip from '@mui/material/Tooltip'
+import useMediaQuery from '@mui/material/useMediaQuery'
+import { useTheme } from '@mui/material/styles'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import CheckIcon from '@mui/icons-material/Check'
 import LogoutIcon from '@mui/icons-material/Logout'
@@ -32,6 +34,8 @@ export default function Header() {
   const sessionId = useSelector((state) => state.game.sessionId)
   const playerName = useSelector((state) => state.game.playerName)
   const { toggleColorMode, mode } = useColorMode()
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
   const [copied, setCopied] = useState(false)
   const [anchorEl, setAnchorEl] = useState(null)
 
@@ -85,7 +89,7 @@ export default function Header() {
         {sessionId ? (
           <>
             <Chip
-              label={`Session ID: ${sessionId}`}
+              label={isMobile ? sessionId : `Session ID: ${sessionId}`}
               size="small"
               deleteIcon={
                 <Tooltip title={copied ? 'Copied!' : 'Copy session ID'} arrow>


### PR DESCRIPTION
## Summary

- On narrow viewports the header overflowed horizontally because the `Session ID: <id>` chip plus the title and user menu didn't fit, forcing the user to scroll the page sideways.
- Use MUI `useMediaQuery` with `theme.breakpoints.down('sm')` to drop the `Session ID: ` prefix on mobile, showing just the 12-char ID — same `xs`/`sm` cutoff already used to hide the "Planning Poker" title.
- Desktop (≥600px) is unchanged: the chip still reads `Session ID: <id>`.

## Test plan

- [x] `vitest run src/containers/__tests__/Header.test.jsx` — 5/5 pass (jsdom defaults to desktop, so the existing `Session ID:` text assertions still hold)
- [x] `eslint` and `prettier --check` clean on `Header.jsx`
- [ ] Manually verify in browser at <600px and ≥600px viewport widths
- [ ] Playwright e2e (`planning-poker.spec.js`) — desktop default viewport, label still matches `^Session ID: [A-Za-z0-9_-]{12}$`

https://claude.ai/code/session_018g2fJGAsG7bmmtbhrMwb5Q

---
_Generated by [Claude Code](https://claude.ai/code/session_018g2fJGAsG7bmmtbhrMwb5Q)_