### PR TITLE
fix(deploy): add explicit id= to Dockerfile cache mounts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 FROM node:22-bookworm-slim AS web-builder
 WORKDIR /web
 COPY planningpoker-web/package.json planningpoker-web/package-lock.json ./
-RUN --mount=type=cache,target=/root/.npm \
+RUN --mount=type=cache,id=npm,target=/root/.npm \
     npm ci
 COPY planningpoker-web/ ./
 RUN npm run build
@@ -29,9 +29,9 @@ COPY planningpoker-web/build.gradle ./planningpoker-web/build.gradle
 COPY planningpoker-api ./planningpoker-api
 # Bring in the freshly built frontend so planningpoker-web:jar can package it
 COPY --from=web-builder /web/build ./planningpoker-web/build
-RUN --mount=type=cache,target=/root/.gradle \
+RUN --mount=type=cache,id=gradle,target=/root/.gradle \
     ./gradlew planningpoker-web:jar --no-daemon
-RUN --mount=type=cache,target=/root/.gradle \
+RUN --mount=type=cache,id=gradle,target=/root/.gradle \
     ./gradlew planningpoker-api:nativeCompile --no-daemon
 
 # Stage 3: runtime -----------------------------------------------------------


### PR DESCRIPTION
## Summary

- Railway's builder rejects two `RUN --mount=type=cache` directives that share the same `target=` without explicit `id=` arguments — even though standard BuildKit defaults `id` to the target path.
- Both gradle cache mounts on lines 32/34 of the Dockerfile (added in #181) target `/root/.gradle`, breaking deploys with: `dockerfile invalid: flag '--mount=type=cache,target=/root/.gradle' is missing an id argument at Line 34`
- Add explicit `id=npm` and `id=gradle` to all three cache mounts. Both gradle mounts share the same id so they continue to share the cache layer.

## Test plan

- [ ] Railway deploy succeeds (the previous failed deploy is the test signal)
- [ ] Cache hit on the second deploy proves the shared `id=gradle` works as before

https://claude.ai/code/session_018g2fJGAsG7bmmtbhrMwb5Q

---
_Generated by [Claude Code](https://claude.ai/code/session_018g2fJGAsG7bmmtbhrMwb5Q)_