### PR TITLE
fix(deploy): use Railway's required cache key prefix on Dockerfile mounts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,15 @@
 # Cache mounts on the npm and gradle caches survive across builds even when
 # source COPYs invalidate the surrounding layers — saves 30-60s per cold
 # build. Requires BuildKit (default in modern Docker, used by Railway and
-# GitHub Actions docker/build-push-action).
+# GitHub Actions docker/build-push-action). The `id=s/<service-id>-...`
+# prefix is required by Railway's builder; env vars aren't allowed in
+# mount IDs so the service ID is hardcoded.
 
 # Stage 1: build frontend ----------------------------------------------------
 FROM node:22-bookworm-slim AS web-builder
 WORKDIR /web
 COPY planningpoker-web/package.json planningpoker-web/package-lock.json ./
-RUN --mount=type=cache,id=npm,target=/root/.npm \
+RUN --mount=type=cache,id=s/3a138f12-84af-4eea-b7cf-38f2e8dc8251-npm,target=/root/.npm \
     npm ci
 COPY planningpoker-web/ ./
 RUN npm run build
@@ -29,9 +31,9 @@ COPY planningpoker-web/build.gradle ./planningpoker-web/build.gradle
 COPY planningpoker-api ./planningpoker-api
 # Bring in the freshly built frontend so planningpoker-web:jar can package it
 COPY --from=web-builder /web/build ./planningpoker-web/build
-RUN --mount=type=cache,id=gradle,target=/root/.gradle \
+RUN --mount=type=cache,id=s/3a138f12-84af-4eea-b7cf-38f2e8dc8251-gradle,target=/root/.gradle \
     ./gradlew planningpoker-web:jar --no-daemon
-RUN --mount=type=cache,id=gradle,target=/root/.gradle \
+RUN --mount=type=cache,id=s/3a138f12-84af-4eea-b7cf-38f2e8dc8251-gradle,target=/root/.gradle \
     ./gradlew planningpoker-api:nativeCompile --no-daemon
 
 # Stage 3: runtime -----------------------------------------------------------


### PR DESCRIPTION
## Summary

- Railway's builder rejected #184 with: `dockerfile invalid: flag '--mount=type=cache,id=gradle,target=/root/.gradle' is missing the cacheKey prefix from its id at Line 34`
- Railway requires cache mount IDs in the form `s/<service-id>-<cache-name>` ([Railway docs](https://docs.railway.com/builds/dockerfiles)), and env vars are not permitted inside mount IDs — the service ID must be hardcoded.
- Apply the prefix to all three cache mounts (`npm`, `gradle`, `gradle`) and document the requirement in the comment block.

The hardcoded ID exposes the Railway service ID in source, which is fine — service IDs are not secrets and are only meaningful inside Railway's build cache.

## Test plan

- [ ] Railway deploy succeeds (the failed deploy at `b4a6f12d-97be-4444-83e7-77be57dd45ea` is the regression signal)
- [ ] `native-image` GitHub Actions job still builds the Dockerfile cleanly (BuildKit treats unknown IDs as fresh caches, so CI is unaffected)

https://claude.ai/code/session_018g2fJGAsG7bmmtbhrMwb5Q

---
_Generated by [Claude Code](https://claude.ai/code/session_018g2fJGAsG7bmmtbhrMwb5Q)_