### PR TITLE
perf(docker): switch runtime image to distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,18 +36,25 @@ RUN --mount=type=cache,id=s/3a138f12-84af-4eea-b7cf-38f2e8dc8251-gradle,target=/
 RUN --mount=type=cache,id=s/3a138f12-84af-4eea-b7cf-38f2e8dc8251-gradle,target=/root/.gradle \
     ./gradlew planningpoker-api:nativeCompile --no-daemon
 
-# Stage 3: runtime -----------------------------------------------------------
-# debian:bookworm-slim with just the libs the native binary needs.
-# libz1 is required by Spring's WebSocket per-message compression; ca-certificates
-# is needed for outbound HTTPS (none today, but cheap to include).
-FROM debian:bookworm-slim
+# Stage 3a: extract libz from debian -----------------------------------------
+# Distroless `base` ships glibc, ca-certificates, libssl and tzdata but not
+# zlib. GraalVM native binaries dynamically link libz.so.1, and Spring's
+# WebSocket per-message compression uses it at runtime. Pull just the .so
+# from a debian-slim helper stage so the runtime image stays minimal.
+FROM debian:bookworm-slim AS lib-source
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates zlib1g \
-    && rm -rf /var/lib/apt/lists/* \
-    && groupadd --system app && useradd --system --gid app app
+    && apt-get install -y --no-install-recommends zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+# Stage 3: runtime -----------------------------------------------------------
+# Distroless: no shell, no apt, no package db. ~25MB image, drops every
+# package the native binary doesn't need. The :nonroot tag pre-sets
+# USER 65532. ca-certificates is bundled (cheap, even though we don't
+# do outbound HTTPS today).
+FROM gcr.io/distroless/base-debian12:nonroot
+COPY --from=lib-source /usr/lib/x86_64-linux-gnu/libz.so.1 /usr/lib/x86_64-linux-gnu/libz.so.1
+COPY --from=native-builder --chown=nonroot:nonroot \
+    /build/planningpoker-api/build/native/nativeCompile/planningpoker /app/planningpoker
 WORKDIR /app
-COPY --from=native-builder /build/planningpoker-api/build/native/nativeCompile/planningpoker /app/planningpoker
-RUN chown app:app /app/planningpoker
-USER app
 EXPOSE 9000
 ENTRYPOINT ["/app/planningpoker"]


### PR DESCRIPTION
## Summary
- Replace `debian:bookworm-slim` runtime with `gcr.io/distroless/base-debian12:nonroot` — no shell, no apt, no package db
- Image drops from ~80MB to ~25MB, faster cold pulls and smaller attack surface
- Tiny debian-slim helper stage extracts `libz.so.1` (distroless base lacks it; GraalVM native binaries link zlib dynamically and Spring's WebSocket per-message compression uses it)
- `:nonroot` tag pre-sets USER 65532, replacing the explicit `groupadd`/`useradd`

## Risks
The container fails to start if any other lib the binary needs is missing from distroless base + libz. Distroless `base-debian12` includes glibc, libssl3, openssl, ca-certificates and tzdata. If GraalVM's native binary links `libgcc_s` or `libstdc++`, we'd need to either copy those in or upgrade to `gcr.io/distroless/cc-debian12` (~30MB).

## Test plan
- [ ] CI `native-image` job builds the Dockerfile and smoke-tests /version, /createSession, /sessionUsers, /stomp/info — that's the real gate
- [ ] Verify image size after green build (`docker images planningpoker:ci`)
- [ ] Watch first Railway deploy — boot time and `/actuator/health` should match current
- [ ] Hold for human review before merge — if CI is green and the user confirms, merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)