### PR TITLE
fix(ci): serialize semantic-release across rapid master pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,6 +252,16 @@ jobs:
   release:
     needs: [unit-tests, e2e-tests, native-image]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    # Serialize across all master pushes so two rapid merges can't run
+    # semantic-release in parallel (which would race on tag pushes and
+    # next-version computation). cancel-in-progress: false queues the
+    # newer run behind a running one — GitHub keeps at most one pending
+    # + one running per group, so a third push supersedes the queued
+    # one and that's fine: the latest run sees every commit since the
+    # last tag and produces the right cumulative release.
+    concurrency:
+      group: release
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Add a job-level concurrency group on the `release` job so two rapid master pushes can't run semantic-release in parallel
- Group key is just `release` (master is the only ref that triggers this job, guarded by the existing `if:`), so all release runs serialize across the repo
- `cancel-in-progress: false` lets a running release finish; GitHub queues at most one pending + one running per group, so a third push supersedes the queued one — fine, since the newest run sees every commit since the last tag and produces the right cumulative release

## Why
The workflow-level concurrency at `ci.yml:9-11` only cancels in-progress runs for pull requests, so master-push runs go in parallel and both eventually reach `release`. Two `npx semantic-release` processes racing on:

- reading git tags
- computing the next version
- pushing the new tag back

…have so far gotten away with it because master pushes are infrequent, but it's a latent bug. Cheaper to add ten lines now than debug a botched release later.

## Test plan
- [ ] CI passes (the `release` job is gated to master pushes, so it's skipped on this PR — we'll see the new concurrency group take effect on the merge commit's run, and on any subsequent master push)
- [ ] After merge: confirm the next master push triggers exactly one `release` run and produces the expected version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)