### PR TITLE
fix(web): escape hyphen in username pattern for regex `v` flag

### DIFF
--- a/planningpoker-web/src/config/Constants.js
+++ b/planningpoker-web/src/config/Constants.js
@@ -5,7 +5,9 @@ export const API_ROOT_URL = ''
 // hyphens, underscores. The anchored RegExp is derived from the same source.
 export const USERNAME_MIN = 2
 export const USERNAME_MAX = 20
-export const USERNAME_PATTERN = `[a-zA-Z0-9 _-]{${USERNAME_MIN},${USERNAME_MAX}}`
+// Hyphen is escaped so the pattern is valid under the regex `v` flag, which
+// modern browsers apply to the HTML5 `pattern` attribute.
+export const USERNAME_PATTERN = `[a-zA-Z0-9 _\\-]{${USERNAME_MIN},${USERNAME_MAX}}`
 export const USERNAME_REGEX = new RegExp(`^${USERNAME_PATTERN}$`)
 export const USERNAME_HELPER = `${USERNAME_MIN}-${USERNAME_MAX} characters: letters, numbers, spaces, hyphens, underscores`
 

--- a/planningpoker-web/src/config/Constants.test.js
+++ b/planningpoker-web/src/config/Constants.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import {
+  USERNAME_PATTERN,
+  USERNAME_REGEX,
+  USERNAME_MIN,
+  USERNAME_MAX,
+} from './Constants'
+
+describe('USERNAME_PATTERN', () => {
+  it('is a valid regex under the `v` flag (HTML5 pattern attribute)', () => {
+    // Browsers apply the `v` flag to the HTML5 `pattern` attribute. Under `v`,
+    // an unescaped `-` between two operands inside a character class is a
+    // syntax error, so this anchors that the pattern stays `v`-compatible.
+    expect(() => new RegExp(`^${USERNAME_PATTERN}$`, 'v')).not.toThrow()
+  })
+
+  it('accepts letters, digits, spaces, hyphens, and underscores', () => {
+    expect(USERNAME_REGEX.test('Alice')).toBe(true)
+    expect(USERNAME_REGEX.test('Bob_42')).toBe(true)
+    expect(USERNAME_REGEX.test('Jean-Luc')).toBe(true)
+    expect(USERNAME_REGEX.test('Two Words')).toBe(true)
+  })
+
+  it('rejects names shorter than the minimum', () => {
+    expect(USERNAME_REGEX.test('a'.repeat(USERNAME_MIN - 1))).toBe(false)
+  })
+
+  it('rejects names longer than the maximum', () => {
+    expect(USERNAME_REGEX.test('a'.repeat(USERNAME_MAX + 1))).toBe(false)
+  })
+
+  it('rejects disallowed characters', () => {
+    expect(USERNAME_REGEX.test('bad!')).toBe(false)
+    expect(USERNAME_REGEX.test('drop;table')).toBe(false)
+    expect(USERNAME_REGEX.test('emoji😀')).toBe(false)
+  })
+})

--- a/planningpoker-web/src/config/Constants.test.js
+++ b/planningpoker-web/src/config/Constants.test.js
@@ -1,10 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import {
-  USERNAME_PATTERN,
-  USERNAME_REGEX,
-  USERNAME_MIN,
-  USERNAME_MAX,
-} from './Constants'
+import { USERNAME_PATTERN, USERNAME_REGEX, USERNAME_MIN, USERNAME_MAX } from './Constants'
 
 describe('USERNAME_PATTERN', () => {
   it('is a valid regex under the `v` flag (HTML5 pattern attribute)', () => {


### PR DESCRIPTION
## Summary
- Modern browsers apply the regex `v` flag to the HTML5 `pattern` attribute. Under `v`, an unescaped `-` between two operands inside a character class is a syntax error, so `[a-zA-Z0-9 _-]{2,20}` fails to compile and the username input's `pattern` attribute is rejected.
- Escape the trailing hyphen in `USERNAME_PATTERN` so it's valid under both legacy and `v` semantics.
- Add `Constants.test.js` that compiles the pattern with `new RegExp(..., 'v')` plus accept/reject coverage, so a future regression is caught at unit-test time.

## Test plan
- [x] `npx vitest run src/config/Constants.test.js` — 5/5 pass
- [ ] CI lint + unit + e2e + native-image
- [ ] Manual: load `/host`, type a name with a hyphen, confirm no console error and form submits

https://claude.ai/code/session_01QsahCucVrdrDAMzutbGx9o

---
_Generated by [Claude Code](https://claude.ai/code/session_01QsahCucVrdrDAMzutbGx9o)_