### PR TITLE
fix(web): stop LiveAnnouncer from triggering horizontal scroll

### DIFF
--- a/planningpoker-web/src/components/LiveAnnouncer.jsx
+++ b/planningpoker-web/src/components/LiveAnnouncer.jsx
@@ -8,10 +8,11 @@ export default function LiveAnnouncer({ message }) {
       aria-atomic="true"
       sx={{
         position: 'absolute',
-        width: 1,
-        height: 1,
+        width: '1px',
+        height: '1px',
         overflow: 'hidden',
         clip: 'rect(0 0 0 0)',
+        clipPath: 'inset(50%)',
         whiteSpace: 'nowrap',
         border: 0,
         p: 0,


### PR DESCRIPTION
## Summary

The visually-hidden `LiveAnnouncer` (the polite-live region we use for screen-reader announcements like "Votes revealed" / "Consensus: 5") was the source of the horizontal scroll on the `/game` route on desktop.

Its sx used MUI's numeric shorthand `width: 1` / `height: 1`, which the sx system resolves to `100%` — not `1px`. Combined with `position: absolute` and no explicit `top`/`left`, the element ballooned to 1280px wide (sized against the initial containing block) but rendered at its in-flow static position inside `<GamePane>`, pushing the document ~113 px past the viewport.

Fix:

- Use explicit `'1px'` strings for `width`/`height`.
- Add `clipPath: 'inset(50%)'` — the modern equivalent of the deprecated `clip: rect(0 0 0 0)` — so the element stays a true 1 px sliver in browsers that ignore `clip` on non-positioned elements.

Verified via Playwright on `/game` at 1920, 1440, 1280, 1024, 768, and 375 px viewports — `scrollWidth === clientWidth` everywhere, no horizontal scroll.

## Test plan

- [ ] `cd planningpoker-web && npx playwright test`
- [ ] Manually open `/game` on desktop and confirm the body no longer scrolls horizontally
- [ ] Confirm screen-reader announcements still fire on vote reveal / consensus change (the element is still in the DOM, just truly visually hidden)

https://claude.ai/code/session_01Nwj16hcWRW7iDtpDfp9tWt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nwj16hcWRW7iDtpDfp9tWt)_