### PR TITLE
chore: add project Claude Code settings with Railway deploy allowlist

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__Railway__list-deployments",
+      "mcp__github__push_files",
+      "Bash(git fetch origin master*)",
+      "Bash(git rev-parse*)",
+      "Bash(TZ='Europe/Amsterdam' date*)",
+      "Bash(sleep 120*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,8 @@ node_modules/
 bin/
 
 # Claude / AI tooling
-.claude/
+.claude/*
+!.claude/settings.json
 .playwright-mcp/
 
 # Git worktrees


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.json` with a permissions allowlist for the Railway deploy routine tools (`mcp__Railway__list-deployments`, `mcp__github__push_files`) and the Bash commands it uses (`git fetch`, `git rev-parse`, `date`, `sleep`)
- Updates `.gitignore` to track `.claude/settings.json` (project-level) while keeping the rest of `.claude/` out of version control

## Test plan

- [ ] Confirm `.claude/settings.json` is present on the branch and not ignored by git
- [ ] Run the Railway deploy routine and verify no permission prompts appear for the allowlisted tools

https://claude.ai/code/session_013UHqZfDoNdwdxXsKWebHkX

---
_Generated by [Claude Code](https://claude.ai/code/session_013UHqZfDoNdwdxXsKWebHkX)_