### PR TITLE
feat(web): skip "?" in auto-consensus and tie-break to the larger value

### DIFF
--- a/planningpoker-web/src/containers/GamePane.jsx
+++ b/planningpoker-web/src/containers/GamePane.jsx
@@ -15,6 +15,7 @@ export default function GamePane({ connected }) {
   const spectators = useSelector((state) => state.spectators)
   const isSpectator = useSelector((state) => state.game.isSpectator)
   const consensusOverride = useSelector((state) => state.consensus.value)
+  const legalEstimates = useSelector((state) => state.game.legalEstimates)
   const showResults = voted || isSpectator
 
   const [announcement, setAnnouncement] = useState('')
@@ -22,7 +23,7 @@ export default function GamePane({ connected }) {
   const consensusDebounceRef = useRef(null)
   const lastAnnouncedConsensusRef = useRef(null)
 
-  const autoConsensus = calcConsensus(results)
+  const autoConsensus = calcConsensus(results, legalEstimates)
   const displayConsensus = consensusOverride || autoConsensus
 
   // Dedup the reveal announcement off the voted state transition (not raw WS

--- a/planningpoker-web/src/containers/Results.jsx
+++ b/planningpoker-web/src/containers/Results.jsx
@@ -28,7 +28,7 @@ export default function Results() {
   const legalEstimates = useSelector((state) => state.game.legalEstimates)
   const consensusOverride = useSelector((state) => state.consensus.value)
 
-  const autoConsensus = calcConsensus(results)
+  const autoConsensus = calcConsensus(results, legalEstimates)
   const displayConsensus = consensusOverride || autoConsensus
   const consensusCount = displayConsensus
     ? results.filter((r) => r.estimateValue === displayConsensus).length

--- a/planningpoker-web/src/containers/SessionHistory.jsx
+++ b/planningpoker-web/src/containers/SessionHistory.jsx
@@ -18,6 +18,7 @@ const fmtTime = (iso) =>
 export default function SessionHistory({ consensusOverride = null, includeInflight = false }) {
   const sessionId = useSelector((state) => state.game.sessionId)
   const currentLabel = useSelector((state) => state.game.currentLabel)
+  const legalEstimates = useSelector((state) => state.game.legalEstimates)
   const rounds = useSelector((state) => state.rounds)
   const users = useSelector((state) => state.users)
   const spectators = useSelector((state) => state.spectators)
@@ -36,7 +37,7 @@ export default function SessionHistory({ consensusOverride = null, includeInflig
     if (hasInflightRound) {
       allRounds.push({
         label: currentLabel,
-        consensus: consensusOverride || calcConsensus(results),
+        consensus: consensusOverride || calcConsensus(results, legalEstimates),
         votes: [...results],
         timestamp: new Date().toISOString(),
       })

--- a/planningpoker-web/src/utils/consensus.js
+++ b/planningpoker-web/src/utils/consensus.js
@@ -1,4 +1,27 @@
-export function calcConsensus(results) {
+// "?" means "unsure" — treat it as an abstention for auto-pick so a noisy mix of unsures can't
+// hijack the consensus. The host can still set "?" manually via the consensus card rail.
+const UNSURE = '?'
+
+// Tie-break to the larger value so forecasts lean conservative (over- > under-estimate).
+// "Larger" is defined by position in legalEstimates when provided — that captures intent for
+// non-numeric schemes (XS < S < ... < XXL) and for custom schemes in the host's chosen order.
+// Without a scheme, fall back to numeric comparison if both values parse as numbers, then to
+// lexical order as a last resort.
+function compareValues(a, b, legalEstimates) {
+  if (legalEstimates && legalEstimates.length > 0) {
+    const ai = legalEstimates.indexOf(a)
+    const bi = legalEstimates.indexOf(b)
+    if (ai !== -1 && bi !== -1) return ai - bi
+    if (ai !== -1) return 1
+    if (bi !== -1) return -1
+  }
+  const an = Number(a)
+  const bn = Number(b)
+  if (Number.isFinite(an) && Number.isFinite(bn)) return an - bn
+  return a.localeCompare(b)
+}
+
+export function calcConsensus(results, legalEstimates = null) {
   if (!results || results.length === 0) return null
 
   const counts = {}
@@ -6,20 +29,22 @@ export function calcConsensus(results) {
     counts[estimateValue] = (counts[estimateValue] || 0) + 1
   }
 
-  const maxCount = Math.max(...Object.values(counts))
-  const candidates = Object.keys(counts)
-    .filter((v) => counts[v] === maxCount)
-    .sort()
+  const candidates = Object.keys(counts).filter((v) => v !== UNSURE)
+  if (candidates.length === 0) return null
 
-  return candidates[0]
+  const maxCount = Math.max(...candidates.map((v) => counts[v]))
+  const tied = candidates.filter((v) => counts[v] === maxCount)
+  if (tied.length === 1) return tied[0]
+
+  return [...tied].sort((a, b) => compareValues(a, b, legalEstimates)).pop()
 }
 
-export function calcStats(results) {
+export function calcStats(results, legalEstimates = null) {
   if (!results || results.length === 0) {
     return { mode: null, min: null, max: null, variance: null }
   }
 
-  const mode = calcConsensus(results)
+  const mode = calcConsensus(results, legalEstimates)
 
   const numericValues = results
     .map(({ estimateValue }) => Number(estimateValue))

--- a/planningpoker-web/src/utils/consensus.test.js
+++ b/planningpoker-web/src/utils/consensus.test.js
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest'
 import { calcConsensus, calcStats } from './consensus'
 
+const FIB = ['1', '2', '3', '5', '8', '13', '?']
+const TSHIRT = ['XS', 'S', 'M', 'L', 'XL', 'XXL', '?']
+
 describe('calcConsensus', () => {
   it('returns mode when one value has most votes', () => {
     const results = [
@@ -8,40 +11,102 @@ describe('calcConsensus', () => {
       { userName: 'b', estimateValue: '5' },
       { userName: 'c', estimateValue: '3' },
     ]
-    expect(calcConsensus(results)).toBe('5')
-  })
-
-  it('returns alphabetically first value on tie', () => {
-    const results = [
-      { userName: 'a', estimateValue: '5' },
-      { userName: 'b', estimateValue: '3' },
-    ]
-    expect(calcConsensus(results)).toBe('3')
-  })
-
-  it('returns null for empty array', () => {
-    expect(calcConsensus([])).toBeNull()
+    expect(calcConsensus(results, FIB)).toBe('5')
   })
 
   it('returns sole value for single voter', () => {
-    expect(calcConsensus([{ userName: 'a', estimateValue: '8' }])).toBe('8')
+    expect(calcConsensus([{ userName: 'a', estimateValue: '8' }], FIB)).toBe('8')
   })
 
-  it('handles three-way tie by picking alphabetically first', () => {
-    const results = [
-      { userName: 'a', estimateValue: 'M' },
-      { userName: 'b', estimateValue: 'L' },
-      { userName: 'c', estimateValue: 'S' },
-    ]
-    expect(calcConsensus(results)).toBe('L')
+  it('returns null for empty array', () => {
+    expect(calcConsensus([], FIB)).toBeNull()
+  })
+
+  describe('tie-break: prefer larger value', () => {
+    it('picks the numerically larger value on a numeric tie', () => {
+      const results = [
+        { userName: 'a', estimateValue: '5' },
+        { userName: 'b', estimateValue: '3' },
+      ]
+      expect(calcConsensus(results, FIB)).toBe('5')
+    })
+
+    it('picks the larger value via scheme order for a T-shirt tie', () => {
+      const results = [
+        { userName: 'a', estimateValue: 'M' },
+        { userName: 'b', estimateValue: 'L' },
+        { userName: 'c', estimateValue: 'S' },
+      ]
+      expect(calcConsensus(results, TSHIRT)).toBe('L')
+    })
+
+    it('respects custom-scheme ordering when picking the larger value', () => {
+      const custom = ['tiny', 'small', 'medium', 'large', 'huge', '?']
+      const results = [
+        { userName: 'a', estimateValue: 'small' },
+        { userName: 'b', estimateValue: 'large' },
+      ]
+      expect(calcConsensus(results, custom)).toBe('large')
+    })
+
+    it('falls back to numeric comparison when no scheme is provided', () => {
+      const results = [
+        { userName: 'a', estimateValue: '5' },
+        { userName: 'b', estimateValue: '13' },
+      ]
+      expect(calcConsensus(results)).toBe('13')
+    })
+  })
+
+  describe('"?" handling', () => {
+    it('does not auto-pick "?" even when it is the most popular', () => {
+      const results = [
+        { userName: 'a', estimateValue: '?' },
+        { userName: 'b', estimateValue: '?' },
+        { userName: 'c', estimateValue: '5' },
+      ]
+      expect(calcConsensus(results, FIB)).toBe('5')
+    })
+
+    it('returns null when every vote is "?"', () => {
+      const results = [
+        { userName: 'a', estimateValue: '?' },
+        { userName: 'b', estimateValue: '?' },
+      ]
+      expect(calcConsensus(results, FIB)).toBeNull()
+    })
+
+    it('ignores "?" in tie-break even when "?" ties with a real value', () => {
+      const results = [
+        { userName: 'a', estimateValue: '?' },
+        { userName: 'b', estimateValue: '?' },
+        { userName: 'c', estimateValue: '8' },
+        { userName: 'd', estimateValue: '8' },
+        { userName: 'e', estimateValue: '5' },
+      ]
+      expect(calcConsensus(results, FIB)).toBe('8')
+    })
+
+    it('still picks the larger non-"?" value when "?" ties with multiple real values', () => {
+      const results = [
+        { userName: 'a', estimateValue: '?' },
+        { userName: 'b', estimateValue: '?' },
+        { userName: 'c', estimateValue: '3' },
+        { userName: 'd', estimateValue: '3' },
+        { userName: 'e', estimateValue: '8' },
+        { userName: 'f', estimateValue: '8' },
+      ]
+      expect(calcConsensus(results, FIB)).toBe('8')
+    })
   })
 })
 
 describe('calcStats', () => {
   it('returns mode, min, max, variance for numeric values', () => {
     const results = [{ estimateValue: '1' }, { estimateValue: '3' }, { estimateValue: '5' }]
-    const stats = calcStats(results)
-    expect(stats.mode).toBe('1')
+    const stats = calcStats(results, FIB)
+    // three-way numeric tie tie-breaks to the larger value
+    expect(stats.mode).toBe('5')
     expect(stats.min).toBe('1')
     expect(stats.max).toBe('5')
     expect(stats.variance).toBe('2.67')
@@ -49,20 +114,26 @@ describe('calcStats', () => {
 
   it('returns mode only (null for numeric stats) for non-numeric values', () => {
     const results = [{ estimateValue: 'M' }, { estimateValue: 'L' }, { estimateValue: 'M' }]
-    const stats = calcStats(results)
+    const stats = calcStats(results, TSHIRT)
     expect(stats.mode).toBe('M')
     expect(stats.min).toBeNull()
     expect(stats.max).toBeNull()
     expect(stats.variance).toBeNull()
   })
 
-  it('returns all nulls for numeric stats when all same value', () => {
+  it('returns all values for numeric stats when all same value', () => {
     const results = [{ estimateValue: '5' }, { estimateValue: '5' }, { estimateValue: '5' }]
-    const stats = calcStats(results)
+    const stats = calcStats(results, FIB)
     expect(stats.mode).toBe('5')
     expect(stats.min).toBe('5')
     expect(stats.max).toBe('5')
     expect(stats.variance).toBe('0.00')
+  })
+
+  it('returns null mode when every vote is "?"', () => {
+    const results = [{ estimateValue: '?' }, { estimateValue: '?' }]
+    const stats = calcStats(results, FIB)
+    expect(stats.mode).toBeNull()
   })
 
   it('returns null for empty results', () => {

--- a/planningpoker-web/tests/session-labels-csv.spec.js
+++ b/planningpoker-web/tests/session-labels-csv.spec.js
@@ -263,17 +263,17 @@ test.describe('Consensus', () => {
 
       await expect(hostPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
 
-      // Mode picks '5' (alphabetical tiebreak); host clicks the '8' card to override
-      const fiveCard = hostPage.getByRole('button', { name: /^Set consensus to 5/ })
-      await expect(fiveCard).toHaveAttribute('aria-pressed', 'true')
-      await hostPage.getByRole('button', { name: /^Set consensus to 8/ }).click()
+      // Auto-consensus picks '8' (tie → larger value); host clicks the '5' card to override
+      const eightCard = hostPage.getByRole('button', { name: /^Set consensus to 8/ })
+      await expect(eightCard).toHaveAttribute('aria-pressed', 'true')
+      await hostPage.getByRole('button', { name: /^Set consensus to 5/ }).click()
 
       // The overridden value should now be selected
-      await expect(hostPage.getByRole('button', { name: /^Set consensus to 8/ })).toHaveAttribute(
+      await expect(hostPage.getByRole('button', { name: /^Set consensus to 5/ })).toHaveAttribute(
         'aria-pressed',
         'true',
       )
-      await expect(fiveCard).toHaveAttribute('aria-pressed', 'false')
+      await expect(eightCard).toHaveAttribute('aria-pressed', 'false')
     } finally {
       await hostCtx.close()
       await playerCtx.close()


### PR DESCRIPTION
## Summary
- `?` is excluded from auto-consensus (most-popular `?` no longer wins). The host can still set `?` manually via the consensus card rail.
- Ties resolve to the larger value — by `legalEstimates` index when known, so T-shirt sizes (`XS<…<XXL`) and custom schemes follow the host's ordering. Falls back to numeric, then lexical.
- `calcStats` threads `legalEstimates` through to its mode for parity.

## Test plan
- [x] `vitest run` — all 246 tests pass, including new `consensus.test.js` cases:
  - numeric tie picks larger
  - T-shirt tie picks larger via scheme order
  - custom-scheme ordering respected
  - `?` excluded when most popular
  - all-`?` returns null (no auto-consensus)
  - `?` ignored in tie-break with real values
- [ ] CI green
- [ ] Manual smoke: vote `?, ?, 5` → consensus shows `5`; vote all `?` → no auto-consensus; host can still click `?` to lock it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)