### PR TITLE
feat(web): copy session summary to clipboard as markdown

### DIFF
--- a/planningpoker-web/src/containers/SessionHistory.jsx
+++ b/planningpoker-web/src/containers/SessionHistory.jsx
@@ -3,11 +3,15 @@ import { useSelector } from 'react-redux'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import Button from '@mui/material/Button'
+import Snackbar from '@mui/material/Snackbar'
+import Alert from '@mui/material/Alert'
 import DownloadIcon from '@mui/icons-material/Download'
+import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import { calcConsensus } from '../utils/consensus'
 import { generateCsv, downloadCsv } from '../utils/csvExport'
+import { generateMarkdownTable, copyToClipboard } from '../utils/markdownExport'
 
 const fmtTime = (iso) =>
   new Date(iso).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
@@ -25,6 +29,7 @@ export default function SessionHistory({ consensusOverride = null, includeInflig
   const results = useSelector((state) => state.results)
   const voted = useSelector((state) => state.voted)
   const [historyOpen, setHistoryOpen] = useState(false)
+  const [toast, setToast] = useState(null)
 
   const hasInflightRound = includeInflight && voted && results.length > 0
   const hasAnyHistory = rounds.length > 0 || hasInflightRound
@@ -32,7 +37,7 @@ export default function SessionHistory({ consensusOverride = null, includeInflig
 
   if (!hasAnyHistory) return null
 
-  const handleExportCsv = () => {
+  const buildAllRounds = () => {
     const allRounds = [...rounds]
     if (hasInflightRound) {
       allRounds.push({
@@ -42,6 +47,11 @@ export default function SessionHistory({ consensusOverride = null, includeInflig
         timestamp: new Date().toISOString(),
       })
     }
+    return allRounds
+  }
+
+  const handleExportCsv = () => {
+    const allRounds = buildAllRounds()
     // Include all current session users (excluding spectators, who never vote) plus any
     // historical voters (who may have since left)
     const spectatorSet = new Set((spectators || []).map((s) => s.toLowerCase()))
@@ -50,6 +60,16 @@ export default function SessionHistory({ consensusOverride = null, includeInflig
     const allPlayers = [...new Set([...voters, ...historicalVoters])].sort()
     const csv = generateCsv(allRounds, allPlayers)
     downloadCsv(csv, `planning-poker-${sessionId}.csv`)
+  }
+
+  const handleCopyMarkdown = async () => {
+    const markdown = generateMarkdownTable(buildAllRounds())
+    try {
+      await copyToClipboard(markdown)
+      setToast({ severity: 'success', message: 'Copied markdown to clipboard' })
+    } catch {
+      setToast({ severity: 'error', message: 'Could not copy to clipboard' })
+    }
   }
 
   return (
@@ -103,15 +123,40 @@ export default function SessionHistory({ consensusOverride = null, includeInflig
             Session history · {totalRounds} {totalRounds === 1 ? 'round' : 'rounds'}
           </Typography>
         )}
-        <Button
-          variant="outlined"
-          size="small"
-          startIcon={<DownloadIcon />}
-          onClick={handleExportCsv}
-        >
-          Export CSV
-        </Button>
+        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+          <Button
+            variant="outlined"
+            size="small"
+            startIcon={<ContentCopyIcon />}
+            onClick={handleCopyMarkdown}
+          >
+            Copy as Markdown
+          </Button>
+          <Button
+            variant="outlined"
+            size="small"
+            startIcon={<DownloadIcon />}
+            onClick={handleExportCsv}
+          >
+            Export CSV
+          </Button>
+        </Box>
       </Box>
+      <Snackbar
+        open={Boolean(toast)}
+        autoHideDuration={2500}
+        onClose={() => setToast(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          severity={toast?.severity ?? 'success'}
+          variant="filled"
+          onClose={() => setToast(null)}
+          sx={{ width: '100%' }}
+        >
+          {toast?.message}
+        </Alert>
+      </Snackbar>
       {historyOpen && rounds.length > 0 && (
         <Box
           sx={{

--- a/planningpoker-web/src/containers/__tests__/SessionHistory.test.jsx
+++ b/planningpoker-web/src/containers/__tests__/SessionHistory.test.jsx
@@ -8,9 +8,15 @@ vi.mock('../../utils/csvExport', () => ({
   downloadCsv: vi.fn(),
 }))
 
+vi.mock('../../utils/markdownExport', () => ({
+  generateMarkdownTable: vi.fn(() => 'md-content'),
+  copyToClipboard: vi.fn(() => Promise.resolve()),
+}))
+
 import SessionHistory from '../SessionHistory'
 import { renderWithStore } from '../../testUtils/renderWithStore'
 import { generateCsv, downloadCsv } from '../../utils/csvExport'
+import { generateMarkdownTable, copyToClipboard } from '../../utils/markdownExport'
 
 function baseState(overrides = {}) {
   return {
@@ -358,6 +364,107 @@ describe('SessionHistory', () => {
       })
       const [roundsArg] = generateCsv.mock.calls[0]
       expect(roundsArg).toEqual([completedRound])
+    })
+  })
+
+  describe('Copy as Markdown — voting screen (includeInflight=false)', () => {
+    it('renders the Copy as Markdown button alongside Export CSV', () => {
+      renderWithStore(<SessionHistory />, {
+        preloadedState: baseState({ rounds: [completedRound] }),
+      })
+      expect(screen.getByRole('button', { name: /Copy as Markdown/ })).toBeInTheDocument()
+    })
+
+    it('passes only completed rounds to generateMarkdownTable', async () => {
+      renderWithStore(<SessionHistory />, {
+        preloadedState: baseState({
+          rounds: [completedRound],
+          voted: true,
+          results: [{ userName: 'alice', estimateValue: '13' }],
+        }),
+      })
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /Copy as Markdown/ }))
+      })
+      expect(generateMarkdownTable).toHaveBeenCalledTimes(1)
+      const [roundsArg] = generateMarkdownTable.mock.calls[0]
+      expect(roundsArg).toEqual([completedRound])
+    })
+
+    it('writes the generated markdown to the clipboard', async () => {
+      renderWithStore(<SessionHistory />, {
+        preloadedState: baseState({ rounds: [completedRound] }),
+      })
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /Copy as Markdown/ }))
+      })
+      expect(copyToClipboard).toHaveBeenCalledWith('md-content')
+    })
+
+    it('shows a success toast after a successful copy', async () => {
+      renderWithStore(<SessionHistory />, {
+        preloadedState: baseState({ rounds: [completedRound] }),
+      })
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /Copy as Markdown/ }))
+      })
+      expect(await screen.findByText(/Copied markdown to clipboard/i)).toBeInTheDocument()
+    })
+
+    it('shows an error toast when the clipboard write rejects', async () => {
+      copyToClipboard.mockRejectedValueOnce(new Error('blocked'))
+      renderWithStore(<SessionHistory />, {
+        preloadedState: baseState({ rounds: [completedRound] }),
+      })
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /Copy as Markdown/ }))
+      })
+      expect(await screen.findByText(/Could not copy to clipboard/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('Copy as Markdown — results screen (includeInflight=true)', () => {
+    it('includes the in-flight round in the copied markdown', async () => {
+      renderWithStore(<SessionHistory includeInflight />, {
+        preloadedState: baseState({
+          rounds: [completedRound],
+          voted: true,
+          results: [
+            { userName: 'alice', estimateValue: '8' },
+            { userName: 'bob', estimateValue: '8' },
+          ],
+          game: { currentLabel: 'Story 2' },
+        }),
+      })
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /Copy as Markdown/ }))
+      })
+      const [roundsArg] = generateMarkdownTable.mock.calls[0]
+      expect(roundsArg).toHaveLength(2)
+      expect(roundsArg[0]).toEqual(completedRound)
+      expect(roundsArg[1]).toMatchObject({
+        label: 'Story 2',
+        consensus: '8',
+      })
+    })
+
+    it('honours consensusOverride when building the in-flight round', async () => {
+      renderWithStore(<SessionHistory consensusOverride="13" includeInflight />, {
+        preloadedState: baseState({
+          voted: true,
+          rounds: [completedRound],
+          results: [
+            { userName: 'alice', estimateValue: '5' },
+            { userName: 'bob', estimateValue: '8' },
+          ],
+        }),
+      })
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /Copy as Markdown/ }))
+      })
+      const [roundsArg] = generateMarkdownTable.mock.calls[0]
+      expect(roundsArg).toHaveLength(2)
+      expect(roundsArg[1].consensus).toBe('13')
     })
   })
 

--- a/planningpoker-web/src/utils/markdownExport.js
+++ b/planningpoker-web/src/utils/markdownExport.js
@@ -1,0 +1,46 @@
+// Escape pipes and newlines so a label can't break the table layout when pasted into
+// Jira/Slack/GitHub. Backslash-escape pipe; collapse hard newlines to a single space.
+function escapeCell(value) {
+  const str = value == null ? '' : String(value)
+  return str.replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/\r?\n/g, ' ')
+}
+
+function formatEstimate(round) {
+  if (round.consensus != null && round.consensus !== '') {
+    return escapeCell(round.consensus)
+  }
+  if (Array.isArray(round.votes) && round.votes.length > 0) {
+    return round.votes
+      .map((v) => `${escapeCell(v.userName)}: ${escapeCell(v.estimateValue)}`)
+      .join(', ')
+  }
+  return '—'
+}
+
+export function generateMarkdownTable(rounds) {
+  const lines = ['| Label | Estimate |', '| --- | --- |']
+  for (const round of rounds) {
+    const label = round.label ? escapeCell(round.label) : '_No label_'
+    lines.push(`| ${label} | ${formatEstimate(round)} |`)
+  }
+  return lines.join('\n')
+}
+
+export async function copyToClipboard(text) {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text)
+    return
+  }
+  // Fallback for non-secure contexts and older browsers.
+  const ta = document.createElement('textarea')
+  ta.value = text
+  ta.style.position = 'fixed'
+  ta.style.opacity = '0'
+  document.body.appendChild(ta)
+  ta.select()
+  try {
+    document.execCommand('copy')
+  } finally {
+    document.body.removeChild(ta)
+  }
+}

--- a/planningpoker-web/src/utils/markdownExport.test.js
+++ b/planningpoker-web/src/utils/markdownExport.test.js
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { generateMarkdownTable, copyToClipboard } from './markdownExport'
+
+const round = (overrides = {}) => ({
+  label: 'Login page',
+  consensus: '5',
+  timestamp: '2026-04-08T10:00:00.000Z',
+  votes: [
+    { userName: 'Alice', estimateValue: '5' },
+    { userName: 'Bob', estimateValue: '5' },
+  ],
+  ...overrides,
+})
+
+describe('generateMarkdownTable', () => {
+  it('renders the header and separator rows', () => {
+    const md = generateMarkdownTable([])
+    expect(md.split('\n')).toEqual(['| Label | Estimate |', '| --- | --- |'])
+  })
+
+  it('renders one body row per round with consensus values', () => {
+    const md = generateMarkdownTable([
+      round({ label: 'Login', consensus: '5' }),
+      round({ label: 'Dashboard', consensus: '8' }),
+    ])
+    const lines = md.split('\n')
+    expect(lines[2]).toBe('| Login | 5 |')
+    expect(lines[3]).toBe('| Dashboard | 8 |')
+  })
+
+  it('escapes pipe characters in labels so they do not break the table', () => {
+    const md = generateMarkdownTable([round({ label: 'Login | Auth', consensus: '5' })])
+    expect(md).toContain('| Login \\| Auth | 5 |')
+  })
+
+  it('escapes backslashes in labels', () => {
+    const md = generateMarkdownTable([round({ label: 'a\\b', consensus: '5' })])
+    expect(md).toContain('| a\\\\b | 5 |')
+  })
+
+  it('collapses newlines in labels to spaces to keep the row on one line', () => {
+    const md = generateMarkdownTable([round({ label: 'line1\nline2', consensus: '5' })])
+    expect(md).toContain('| line1 line2 | 5 |')
+  })
+
+  it('renders "_No label_" for rounds without a label', () => {
+    const md = generateMarkdownTable([round({ label: '' })])
+    expect(md).toContain('| _No label_ |')
+  })
+
+  it('falls back to vote breakdown when consensus is empty', () => {
+    const md = generateMarkdownTable([
+      round({
+        label: 'Split',
+        consensus: '',
+        votes: [
+          { userName: 'Alice', estimateValue: '3' },
+          { userName: 'Bob', estimateValue: '8' },
+        ],
+      }),
+    ])
+    expect(md).toContain('| Split | Alice: 3, Bob: 8 |')
+  })
+
+  it('falls back to vote breakdown when consensus is null', () => {
+    const md = generateMarkdownTable([
+      round({
+        label: 'Split',
+        consensus: null,
+        votes: [{ userName: 'Carol', estimateValue: '13' }],
+      }),
+    ])
+    expect(md).toContain('| Split | Carol: 13 |')
+  })
+
+  it('renders an em-dash when there is no consensus and no votes', () => {
+    const md = generateMarkdownTable([round({ label: 'Empty', consensus: null, votes: [] })])
+    expect(md).toContain('| Empty | — |')
+  })
+
+  it('escapes pipes inside vote breakdown values', () => {
+    const md = generateMarkdownTable([
+      round({
+        label: 'Split',
+        consensus: null,
+        votes: [{ userName: 'A|B', estimateValue: '5|8' }],
+      }),
+    ])
+    expect(md).toContain('A\\|B: 5\\|8')
+  })
+})
+
+describe('copyToClipboard', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('uses navigator.clipboard.writeText when available', async () => {
+    const writeText = vi.fn(() => Promise.resolve())
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+      writable: true,
+    })
+    await copyToClipboard('hello')
+    expect(writeText).toHaveBeenCalledWith('hello')
+  })
+
+  it('falls back to a hidden textarea + execCommand when clipboard API is missing', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    })
+    const exec = vi.fn(() => true)
+    document.execCommand = exec
+    await copyToClipboard('fallback')
+    expect(exec).toHaveBeenCalledWith('copy')
+  })
+})

--- a/planningpoker-web/tests/session-labels-csv.spec.js
+++ b/planningpoker-web/tests/session-labels-csv.spec.js
@@ -494,6 +494,47 @@ test.describe('CSV Export', () => {
   })
 })
 
+test.describe('Copy as Markdown', () => {
+  test('copies a markdown table of completed rounds to the clipboard', async ({ browser }) => {
+    const hostCtx = await browser.newContext({ permissions: ['clipboard-read', 'clipboard-write'] })
+    const playerCtx = await browser.newContext()
+    try {
+      const hostPage = await hostCtx.newPage()
+      const sessionId = await hostGame(hostPage, 'Alice')
+
+      const playerPage = await playerCtx.newPage()
+      await joinGame(playerPage, 'Bob', sessionId)
+
+      await waitForWsReady(playerPage, sessionId, 'Alice')
+
+      const labelInput = hostPage.getByPlaceholder('Item label (optional)')
+      await labelInput.fill('Login flow')
+      await labelInput.press('Enter')
+      await expect(playerPage.getByText('Login flow')).toBeVisible({ timeout: 15000 })
+
+      await hostPage.getByText('5', { exact: true }).click()
+      await playerPage.getByText('5', { exact: true }).click()
+      await expect(hostPage.getByText(/^Round \d+/)).toBeVisible({ timeout: 15000 })
+
+      const copyBtn = hostPage.getByRole('button', { name: 'Copy as Markdown' })
+      await copyBtn.scrollIntoViewIfNeeded()
+      await copyBtn.click()
+
+      await expect(hostPage.getByText('Copied markdown to clipboard')).toBeVisible({
+        timeout: 5000,
+      })
+
+      const clipboardText = await hostPage.evaluate(() => navigator.clipboard.readText())
+      expect(clipboardText).toContain('| Label | Estimate |')
+      expect(clipboardText).toContain('| --- | --- |')
+      expect(clipboardText).toContain('| Login flow | 5 |')
+    } finally {
+      await hostCtx.close()
+      await playerCtx.close()
+    }
+  })
+})
+
 test.describe('Accessibility announcements', () => {
   test('aria-live polite region is mounted on game pane', async ({ browser }) => {
     const hostCtx = await browser.newContext()


### PR DESCRIPTION
Closes #150.

## Summary
- Adds a **Copy as Markdown** button on `SessionHistory` next to **Export CSV**
- Clipboard payload is a `| Label | Estimate |` markdown table — pastes cleanly into Jira / Slack / GitHub
- When a round has no consensus, the estimate cell expands into a per-voter breakdown (`alice: 5, bob: 8`)
- Confirms via a local success toast (`Copied markdown to clipboard`); error toast when the clipboard write rejects
- Pipe and newline characters in labels are escaped/collapsed so they cannot break the table
- Falls back to hidden-textarea + `execCommand('copy')` in non-secure contexts where `navigator.clipboard` is unavailable

## Test plan
- [x] `npx vitest run` — 265 unit tests pass (12 new in `markdownExport.test.js`, 7 new in `SessionHistory.test.jsx`)
- [x] Playwright e2e: voted round → click button → toast appears → clipboard contents match the expected markdown
- [x] `npm run lint` + `npx prettier --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)