### PR TITLE
feat(web): include round number in CSV and markdown exports

### DIFF
--- a/planningpoker-web/src/utils/csvExport.js
+++ b/planningpoker-web/src/utils/csvExport.js
@@ -15,10 +15,10 @@ function escapeField(value) {
 }
 
 export function generateCsv(rounds, playerNames) {
-  const headers = ['Label', 'Consensus', 'Timestamp', ...playerNames]
+  const headers = ['Round', 'Label', 'Consensus', 'Timestamp', ...playerNames]
   const rows = [headers.join(',')]
 
-  for (const round of rounds) {
+  rounds.forEach((round, i) => {
     const voteMap = {}
     for (const { userName, estimateValue } of round.votes) {
       voteMap[userName] = estimateValue
@@ -27,6 +27,7 @@ export function generateCsv(rounds, playerNames) {
     const playerVotes = playerNames.map((name) => escapeField(voteMap[name] || ''))
 
     const row = [
+      escapeField(i + 1),
       escapeField(round.label || ''),
       escapeField(round.consensus || ''),
       escapeField(round.timestamp || ''),
@@ -34,7 +35,7 @@ export function generateCsv(rounds, playerNames) {
     ]
 
     rows.push(row.join(','))
-  }
+  })
 
   return rows.join('\n')
 }

--- a/planningpoker-web/src/utils/csvExport.test.js
+++ b/planningpoker-web/src/utils/csvExport.test.js
@@ -28,15 +28,15 @@ describe('generateCsv', () => {
     const playerNames = ['Alice', 'Bob']
     const csv = generateCsv(rounds, playerNames)
     const lines = csv.split('\n')
-    expect(lines[0]).toBe('Label,Consensus,Timestamp,Alice,Bob')
+    expect(lines[0]).toBe('Round,Label,Consensus,Timestamp,Alice,Bob')
   })
 
   it('produces correct data rows', () => {
     const playerNames = ['Alice', 'Bob']
     const csv = generateCsv(rounds, playerNames)
     const lines = csv.split('\n')
-    expect(lines[1]).toBe('Login page,5,2026-04-08T10:00:00.000Z,5,3')
-    expect(lines[2]).toBe('Dashboard,8,2026-04-08T10:05:00.000Z,8,8')
+    expect(lines[1]).toBe('1,Login page,5,2026-04-08T10:00:00.000Z,5,3')
+    expect(lines[2]).toBe('2,Dashboard,8,2026-04-08T10:05:00.000Z,8,8')
   })
 
   it('uses empty string for missing player vote', () => {
@@ -50,7 +50,7 @@ describe('generateCsv', () => {
     ]
     const csv = generateCsv(roundWithMissingPlayer, ['Alice', 'Bob'])
     const lines = csv.split('\n')
-    expect(lines[1]).toBe('Item 1,5,2026-04-08T10:00:00.000Z,5,')
+    expect(lines[1]).toBe('1,Item 1,5,2026-04-08T10:00:00.000Z,5,')
   })
 
   it('escapes values with commas in double quotes', () => {
@@ -64,7 +64,7 @@ describe('generateCsv', () => {
     ]
     const csv = generateCsv(roundWithComma, ['Alice'])
     const lines = csv.split('\n')
-    expect(lines[1].startsWith('"Fix login, signup flow"')).toBe(true)
+    expect(lines[1]).toBe('1,"Fix login, signup flow",5,2026-04-08T10:00:00.000Z,5')
   })
 
   it('escapes double quotes in values', () => {
@@ -78,7 +78,7 @@ describe('generateCsv', () => {
     ]
     const csv = generateCsv(roundWithQuote, ['Alice'])
     const lines = csv.split('\n')
-    expect(lines[1].startsWith('"He said ""hello"""')).toBe(true)
+    expect(lines[1]).toBe('1,"He said ""hello""",5,2026-04-08T10:00:00.000Z,5')
   })
 
   it('prefixes formula injection characters with single quote', () => {
@@ -93,7 +93,20 @@ describe('generateCsv', () => {
     ]
     const csv = generateCsv(round, ['Alice'])
     const lines = csv.split('\n')
-    expect(lines[1].startsWith('"\'=SUM(A1)"') || lines[1].startsWith("'=SUM(A1)")).toBe(true)
+    expect(lines[1].startsWith('1,"\'=SUM(A1)"') || lines[1].startsWith("1,'=SUM(A1)")).toBe(true)
+  })
+
+  it('numbers rounds sequentially starting at 1', () => {
+    const manyRounds = [
+      { label: 'A', consensus: '1', timestamp: 't1', votes: [] },
+      { label: 'B', consensus: '2', timestamp: 't2', votes: [] },
+      { label: 'C', consensus: '3', timestamp: 't3', votes: [] },
+    ]
+    const csv = generateCsv(manyRounds, [])
+    const lines = csv.split('\n')
+    expect(lines[1].startsWith('1,A,')).toBe(true)
+    expect(lines[2].startsWith('2,B,')).toBe(true)
+    expect(lines[3].startsWith('3,C,')).toBe(true)
   })
 })
 

--- a/planningpoker-web/src/utils/markdownExport.js
+++ b/planningpoker-web/src/utils/markdownExport.js
@@ -18,11 +18,11 @@ function formatEstimate(round) {
 }
 
 export function generateMarkdownTable(rounds) {
-  const lines = ['| Label | Estimate |', '| --- | --- |']
-  for (const round of rounds) {
+  const lines = ['| # | Label | Estimate |', '| --- | --- | --- |']
+  rounds.forEach((round, i) => {
     const label = round.label ? escapeCell(round.label) : '_No label_'
-    lines.push(`| ${label} | ${formatEstimate(round)} |`)
-  }
+    lines.push(`| ${i + 1} | ${label} | ${formatEstimate(round)} |`)
+  })
   return lines.join('\n')
 }
 

--- a/planningpoker-web/src/utils/markdownExport.test.js
+++ b/planningpoker-web/src/utils/markdownExport.test.js
@@ -16,7 +16,7 @@ const round = (overrides = {}) => ({
 describe('generateMarkdownTable', () => {
   it('renders the header and separator rows', () => {
     const md = generateMarkdownTable([])
-    expect(md.split('\n')).toEqual(['| Label | Estimate |', '| --- | --- |'])
+    expect(md.split('\n')).toEqual(['| # | Label | Estimate |', '| --- | --- | --- |'])
   })
 
   it('renders one body row per round with consensus values', () => {
@@ -25,28 +25,28 @@ describe('generateMarkdownTable', () => {
       round({ label: 'Dashboard', consensus: '8' }),
     ])
     const lines = md.split('\n')
-    expect(lines[2]).toBe('| Login | 5 |')
-    expect(lines[3]).toBe('| Dashboard | 8 |')
+    expect(lines[2]).toBe('| 1 | Login | 5 |')
+    expect(lines[3]).toBe('| 2 | Dashboard | 8 |')
   })
 
   it('escapes pipe characters in labels so they do not break the table', () => {
     const md = generateMarkdownTable([round({ label: 'Login | Auth', consensus: '5' })])
-    expect(md).toContain('| Login \\| Auth | 5 |')
+    expect(md).toContain('| 1 | Login \\| Auth | 5 |')
   })
 
   it('escapes backslashes in labels', () => {
     const md = generateMarkdownTable([round({ label: 'a\\b', consensus: '5' })])
-    expect(md).toContain('| a\\\\b | 5 |')
+    expect(md).toContain('| 1 | a\\\\b | 5 |')
   })
 
   it('collapses newlines in labels to spaces to keep the row on one line', () => {
     const md = generateMarkdownTable([round({ label: 'line1\nline2', consensus: '5' })])
-    expect(md).toContain('| line1 line2 | 5 |')
+    expect(md).toContain('| 1 | line1 line2 | 5 |')
   })
 
   it('renders "_No label_" for rounds without a label', () => {
     const md = generateMarkdownTable([round({ label: '' })])
-    expect(md).toContain('| _No label_ |')
+    expect(md).toContain('| 1 | _No label_ |')
   })
 
   it('falls back to vote breakdown when consensus is empty', () => {
@@ -60,7 +60,7 @@ describe('generateMarkdownTable', () => {
         ],
       }),
     ])
-    expect(md).toContain('| Split | Alice: 3, Bob: 8 |')
+    expect(md).toContain('| 1 | Split | Alice: 3, Bob: 8 |')
   })
 
   it('falls back to vote breakdown when consensus is null', () => {
@@ -71,12 +71,24 @@ describe('generateMarkdownTable', () => {
         votes: [{ userName: 'Carol', estimateValue: '13' }],
       }),
     ])
-    expect(md).toContain('| Split | Carol: 13 |')
+    expect(md).toContain('| 1 | Split | Carol: 13 |')
   })
 
   it('renders an em-dash when there is no consensus and no votes', () => {
     const md = generateMarkdownTable([round({ label: 'Empty', consensus: null, votes: [] })])
-    expect(md).toContain('| Empty | — |')
+    expect(md).toContain('| 1 | Empty | — |')
+  })
+
+  it('numbers rounds sequentially starting at 1', () => {
+    const md = generateMarkdownTable([
+      round({ label: 'A' }),
+      round({ label: 'B' }),
+      round({ label: 'C' }),
+    ])
+    const lines = md.split('\n')
+    expect(lines[2].startsWith('| 1 | A ')).toBe(true)
+    expect(lines[3].startsWith('| 2 | B ')).toBe(true)
+    expect(lines[4].startsWith('| 3 | C ')).toBe(true)
   })
 
   it('escapes pipes inside vote breakdown values', () => {

--- a/planningpoker-web/tests/session-labels-csv.spec.js
+++ b/planningpoker-web/tests/session-labels-csv.spec.js
@@ -475,17 +475,18 @@ test.describe('CSV Export', () => {
       expect(header).not.toMatch(/\bMax\b/)
       expect(header).not.toMatch(/\bVariance\b/)
 
-      // Header is exactly: Label,Consensus,Timestamp, then sorted players
-      expect(header).toBe('Label,Consensus,Timestamp,Alice,Bob,Carol')
+      // Header is exactly: Round,Label,Consensus,Timestamp, then sorted players
+      expect(header).toBe('Round,Label,Consensus,Timestamp,Alice,Bob,Carol')
 
-      // Data row: empty label, consensus 5, iso timestamp, Alice=5, Bob=5, Carol=(empty)
-      // Columns 0..2 = Label/Consensus/Timestamp; 3/4/5 = Alice/Bob/Carol
+      // Data row: round 1, empty label, consensus 5, iso timestamp, Alice=5, Bob=5, Carol=(empty)
+      // Columns 0..3 = Round/Label/Consensus/Timestamp; 4/5/6 = Alice/Bob/Carol
       const cols = dataRow.split(',')
-      expect(cols[0]).toBe('') // no label set
-      expect(cols[1]).toBe('5')
-      expect(cols[3]).toBe('5') // Alice
-      expect(cols[4]).toBe('5') // Bob
-      expect(cols[5]).toBe('') // Carol — non-voter, blank
+      expect(cols[0]).toBe('1') // first round
+      expect(cols[1]).toBe('') // no label set
+      expect(cols[2]).toBe('5')
+      expect(cols[4]).toBe('5') // Alice
+      expect(cols[5]).toBe('5') // Bob
+      expect(cols[6]).toBe('') // Carol — non-voter, blank
     } finally {
       await hostCtx.close()
       await voterCtx.close()
@@ -525,9 +526,9 @@ test.describe('Copy as Markdown', () => {
       })
 
       const clipboardText = await hostPage.evaluate(() => navigator.clipboard.readText())
-      expect(clipboardText).toContain('| Label | Estimate |')
-      expect(clipboardText).toContain('| --- | --- |')
-      expect(clipboardText).toContain('| Login flow | 5 |')
+      expect(clipboardText).toContain('| # | Label | Estimate |')
+      expect(clipboardText).toContain('| --- | --- | --- |')
+      expect(clipboardText).toContain('| 1 | Login flow | 5 |')
     } finally {
       await hostCtx.close()
       await playerCtx.close()


### PR DESCRIPTION
## Summary
- Add a leading `Round` column (CSV) and `#` column (markdown) so each exported row carries its 1-based index — matching the `#{i+1}` numbering shown in the session history list.
- Makes it easier to cross-reference rounds when reviewing or sharing exported sessions.

## Test plan
- [x] `vitest` unit tests updated and passing for `csvExport` and `markdownExport`
- [x] Playwright e2e (`session-labels-csv.spec.js`) updated for the new header/row shape
- [x] `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)