### PR TITLE
chore(deps): ignore eslint and @eslint/js major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,17 @@ updates:
         update-types:
           - minor
           - patch
+    # ESLint 10 needs eslint + @eslint/js + eslint-plugin-react bumped together,
+    # which Dependabot cannot do atomically. eslint-plugin-react has no release
+    # supporting ESLint 10 (jsx-eslint/eslint-plugin-react#4018 is fixed upstream
+    # but unpublished). Remove both entries once it ships — see issue #229.
+    ignore:
+      - dependency-name: eslint
+        update-types:
+          - version-update:semver-major
+      - dependency-name: "@eslint/js"
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: npm
     directory: /


### PR DESCRIPTION
## Why

Dependabot kept opening ESLint 10 PRs that can never go green. Closed as unmergeable:

- #227 (`eslint` → 10.6.0) — `ERESOLVE`: `eslint-plugin-react@7.37.5` peers cap at `eslint ^9.7`
- #213 (`@eslint/js` → 10.0.1) — `ERESOLVE`: `@eslint/js@10` peers on `eslint ^10`, root pins `^9`

These are two-thirds of a single 9→10 bump. The third package, `eslint-plugin-react`, has **no published release supporting ESLint 10** (latest `7.37.5`, published 2025-04-03). The fix is merged upstream — [jsx-eslint/eslint-plugin-react#4018](https://github.com/jsx-eslint/eslint-plugin-react/issues/4018), closed 2026-06-11 — but never shipped to npm.

Dependabot can't emit an atomic three-package bump, so without an ignore rule a new failing PR respawns on every 10.x release.

## Why not just force it

Verified empirically — `--legacy-peer-deps` installs fine, then lint hard-crashes:

```
TypeError: Error while loading rule 'react/display-name':
contextOrFilename.getFilename is not a function
    at resolveBasedir (eslint-plugin-react/lib/util/version.js:31:100)
```

The plugin calls eslint 9's `context.getFilename()`, removed in eslint 10. Forcing the peer range trades a red install for a red lint.

## What this does

Ignores **major** updates for `eslint` and `@eslint/js` in the `/planningpoker-web` npm block. Both are needed — ignoring only one lets the other respawn. Minor/patch updates within 9.x flow normally, and no other ecosystem block is touched.

Unblocking steps tracked in #229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)